### PR TITLE
Updates canonical N-Triples to be consistent with N-Quads.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -248,7 +248,7 @@
     <h2>A Canonical form of N-Triples</h2>
     <p>This section defines a canonical form of N-Triples which has
       a completely specified layout.
-      The grammar for the language is the same.</p>
+      The grammar for the language is remains unchanged.</p>
 
     <p>While the N-Triples syntax allows choices for the representation and layout of RDF data,
       the canonical form of N-Triples provides a unique syntactic representation of any triple.
@@ -279,9 +279,9 @@
         <code>U+0009</code> (<code title="HORIZONTAL TAB"><sub>HT</sub></code>),
         <code>U+000A</code> (<code title="LINE FEED"><sub>LF</sub></code>),
         <code>U+000C</code> (<code title="FORM FEED"><sub>FF</sub></code>),
-        <code>U+000D</code>  (<code title="CARRIAGE RETURN"><sub>CR</sub></code>)),
-        <code>U+0022</code> (<code title="DOUBLE QUOTE">&quot;</code>)), and
-        <code>U+005C</code> (<code title="BACKSLASH">\</code>))
+        <code>U+000D</code>  (<code title="CARRIAGE RETURN"><sub>CR</sub></code>),
+        <code>U+0022</code> (<code title="DOUBLE QUOTE">&quot;</code>), and
+        <code>U+005C</code> (<code title="BACKSLASH">\</code>)
         MUST be encoded using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>.
         Characters in the range from <code>U+0000</code> to <code>U+001F</code>
         and <code>U+007F</code>  (<code title="delete"><sub>DEL</sub></code>)

--- a/spec/index.html
+++ b/spec/index.html
@@ -241,10 +241,6 @@
         _:bob <http://xmlns.com/foaf/0.1/knows> _:alice .
         -->
       </pre>
-      <p class="issue" data-number="2">
-        Note open <a href="https://www.w3.org/2001/sw/wiki/RDF1.1_Errata#erratum_30">erratum</a> on aligning the definition and production
-        for blank node lables with Turtle.
-      </p>
     </section>
   </section>
 
@@ -268,36 +264,41 @@
       less variability in layout.
       The grammar for the language is the same.</p>
 
-    <p class="note">Even when not explicitly serializing
-      canonical N-Triples, implementers are encouraged to produce this form.</p>
+    <p class="note">A canonical form of N-Triples can be used to ensure
+      that variations in the syntactic representation of terms
+      within that triple are determined; each code point
+      can be represented by only one of
+      <code><a href="#grammar-production-UCHAR">UCHAR</a></code>,
+      <code><a href="#grammar-production-ECHAR">ECHAR</a></code>,
+      or unencoded character,
+      where the relevant production allows for a choice in representation.</p>
 
     <p>Canonical N-Triples has the following additional constraints on layout:</p>
     <ul>
-      <li>The white space following <code>subject</code>,
-        <code>predicate</code>, 
-        and <code>object</code> MUST be a single space, 
-        (<code>U+0020</code>).  All other locations that allow 
-        white space MUST be empty.</li>
-      <li>There MUST be no comments.</li>
+      <li>White space MUST NOT be used except after
+        <code>subject</code>,
+        <code>predicate</code>,  and
+        <code>object</code>,
+        any of which MUST be a single space (<code>U+0020</code>).</li>
+      <li><a data-cite="RDF12-CONCEPTS#dfn-literal">Literals</a> with the
+        datatype <code>http://www.w3.org/2001/XMLSchema#string</code>
+        MUST NOT use the datatype IRI part of the <a href="#grammar-production-literal">literal</a>,
+        and are represented using only <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.
+      </li>
       <li><code>HEX</code> MUST use only uppercase letters (<code>[A-F]</code>).</li>
-      <li>Characters MUST NOT be represented by <code>UCHAR</code>.</li>
       <li>Within <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
-        only the characters 
+        the characters 
         <code>U+0022</code>, <code>U+005C</code>, <code>U+000A</code>, <code>U+000D</code>
-         are encoded using <code>ECHAR</code>.
-        <code>ECHAR</code> MUST NOT be used for characters that are
-        allowed directly in
-        <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>. </li>
-      <li>The token EOL MUST be a single <code>U+000A</code>.</li>
-      <li>The final EOL MUST be provided.</li>
+        MUST be encoded using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>.
+        Characters in the range from <code>U+0000</code> to <code>U+001F</code> and <code>U+007F</code>
+        not represented using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>
+        MUST be represented by <code><a href="#grammar-production-UCHAR">UCHAR</a></code>.
+        All other characters MUST be represented by their native [[UNICODE]] representation..</li>
+        <li>The token <code><a href="#grammar-production-EOL">EOL</a></code> MUST be a single <code>U+000A</code>.</li>
+        <li>The final <code><a href="#grammar-production-EOL">EOL</a></code> MUST be provided.</li>
+      <li>The token <code><a href="#grammar-production-EOL">EOL</a></code> MUST be a single <code>U+000A</code>.</li>
+      <li>The final <code><a href="#grammar-production-EOL">EOL</a></code> MUST be provided.</li>
     </ul>
-    <div class="issue" data-number="2">
-      Note open errata:
-      <ul>
-        <li><a href="https://www.w3.org/2001/sw/wiki/RDF1.1_Errata#erratum_32">32 – Issues with N-Quads/N-Triples canonicalization</a>.</li>
-        <li><a href="https://www.w3.org/2001/sw/wiki/RDF1.1_Errata#erratum_33">33 – Ambiguity of canonical N-Triples</a></li>
-      </ul>
-    </div>
   </section>
 
   <section id="conformance">
@@ -495,6 +496,9 @@
       better mirroring [[RDF12-TURTLE]].</li>
     <li>Updated the <a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a>
       grammar production to be consisten with with Turtle.</li>
+    <li>Changes <a href="#canonical-ntriples"></a> to clarify
+      use of datatype IRIs and expand the use of escapes
+      in literals.</li>
   </ul>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -260,18 +260,19 @@
 
   <section id="canonical-ntriples">
     <h2>A Canonical form of N-Triples</h2>
-    <p>This section defines a canonical form of N-Triples which has
-      less variability in layout.
+    <p>This section defines a canonical form of N-Triples  which has
+      a completely specified layout.
       The grammar for the language is the same.</p>
 
-    <p class="note">A canonical form of N-Triples can be used to ensure
-      that variations in the syntactic representation of terms
-      within that triple are determined; each code point
+    <p>While the N-Triples syntax allows choices for the representation and layout of RDF data,
+      the canonical form of N-Triples provides a unique syntactic representation of any triple.
+      Each code point
       can be represented by only one of
       <code><a href="#grammar-production-UCHAR">UCHAR</a></code>,
       <code><a href="#grammar-production-ECHAR">ECHAR</a></code>,
       or unencoded character,
-      where the relevant production allows for a choice in representation.</p>
+      where the relevant production allows for a choice in representation.
+      Each triple is represented entirely on a single line with specified white space.</p>
 
     <p>Canonical N-Triples has the following additional constraints on layout:</p>
     <ul>
@@ -285,17 +286,15 @@
         MUST NOT use the datatype IRI part of the <a href="#grammar-production-literal">literal</a>,
         and are represented using only <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.
       </li>
-      <li><code>HEX</code> MUST use only uppercase letters (<code>[A-F]</code>).</li>
+      <li><code><a href="#grammar-production-HEX">HEX</a></code> MUST use only uppercase letters (<code>[A-F]</code>).</li>
       <li>Within <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
         the characters 
         <code>U+0022</code>, <code>U+005C</code>, <code>U+000A</code>, <code>U+000D</code>
         MUST be encoded using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>.
         Characters in the range from <code>U+0000</code> to <code>U+001F</code> and <code>U+007F</code>
-        not represented using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>
+        that are not represented using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>
         MUST be represented by <code><a href="#grammar-production-UCHAR">UCHAR</a></code>.
-        All other characters MUST be represented by their native [[UNICODE]] representation..</li>
-        <li>The token <code><a href="#grammar-production-EOL">EOL</a></code> MUST be a single <code>U+000A</code>.</li>
-        <li>The final <code><a href="#grammar-production-EOL">EOL</a></code> MUST be provided.</li>
+        All other characters MUST be represented by their native [[UNICODE]] representation.</li>
       <li>The token <code><a href="#grammar-production-EOL">EOL</a></code> MUST be a single <code>U+000A</code>.</li>
       <li>The final <code><a href="#grammar-production-EOL">EOL</a></code> MUST be provided.</li>
     </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -248,7 +248,7 @@
     <h2>A Canonical form of N-Triples</h2>
     <p>This section defines a canonical form of N-Triples which has
       a completely specified layout.
-      The grammar for the language is remains unchanged.</p>
+      The grammar for the language is unchanged.</p>
 
     <p>While the N-Triples syntax allows choices for the representation and layout of RDF data,
       the canonical form of N-Triples provides a unique syntactic representation of any triple.
@@ -279,7 +279,7 @@
         <code>U+0009</code> (<code title="HORIZONTAL TAB"><sub>HT</sub></code>),
         <code>U+000A</code> (<code title="LINE FEED"><sub>LF</sub></code>),
         <code>U+000C</code> (<code title="FORM FEED"><sub>FF</sub></code>),
-        <code>U+000D</code>  (<code title="CARRIAGE RETURN"><sub>CR</sub></code>),
+        <code>U+000D</code> (<code title="CARRIAGE RETURN"><sub>CR</sub></code>),
         <code>U+0022</code> (<code title="DOUBLE QUOTE">&quot;</code>), and
         <code>U+005C</code> (<code title="BACKSLASH">\</code>)
         MUST be encoded using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>.

--- a/spec/index.html
+++ b/spec/index.html
@@ -260,7 +260,7 @@
 
   <section id="canonical-ntriples">
     <h2>A Canonical form of N-Triples</h2>
-    <p>This section defines a canonical form of N-Triples  which has
+    <p>This section defines a canonical form of N-Triples which has
       a completely specified layout.
       The grammar for the language is the same.</p>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -274,10 +274,17 @@
       </li>
       <li><code><a href="#grammar-production-HEX">HEX</a></code> MUST use only uppercase letters (<code>[A-F]</code>).</li>
       <li>Within <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
-        the characters 
-        <code>U+0022</code>, <code>U+005C</code>, <code>U+000A</code>, <code>U+000D</code>
+        the characters
+        <code>U+0008</code> (<code title="BACKSPACE"><sub>BS</sub></code>),
+        <code>U+0009</code> (<code title="HORIZONTAL TAB"><sub>HT</sub></code>),
+        <code>U+000A</code> (<code title="LINE FEED"><sub>LF</sub></code>),
+        <code>U+000C</code> (<code title="FORM FEED"><sub>FF</sub></code>),
+        <code>U+000D</code>  (<code title="CARRIAGE RETURN"><sub>CR</sub></code>)),
+        <code>U+0022</code> (<code title="DOUBLE QUOTE">&quot;</code>)), and
+        <code>U+005C</code> (<code title="BACKSLASH">\</code>))
         MUST be encoded using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>.
-        Characters in the range from <code>U+0000</code> to <code>U+001F</code> and <code>U+007F</code>
+        Characters in the range from <code>U+0000</code> to <code>U+001F</code>
+        and <code>U+007F</code>  (<code title="delete"><sub>DEL</sub></code>)
         that are not represented using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>
         MUST be represented by <code><a href="#grammar-production-UCHAR">UCHAR</a></code>.
         All other characters MUST be represented by their native [[UNICODE]] representation.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -95,7 +95,7 @@
       of an <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF Triple</a>.
       These may be separated by white space (spaces <code>U+0020</code> or tabs <code>U+0009</code>).
       This sequence is terminated by a '<code>.</code>'
-      (optionally proceded by white space and/or a comment),
+      (optionally followed by white space and/or a comment),
       and a new line (optional at the end of a document).</p>
 
     <pre id="ex-comments" class="example ntriples" data-transform="updateExample"


### PR DESCRIPTION
Fixes #2.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/pull/19.html" title="Last updated on Apr 18, 2023, 5:11 PM UTC (bacddda)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/19/206b848...bacddda.html" title="Last updated on Apr 18, 2023, 5:11 PM UTC (bacddda)">Diff</a>