### PR TITLE
Support for quoted triples.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -159,7 +159,7 @@
       <p>Comments are treated as white space, and may be given after a '<code>#</code>' that is not part of
         another lexical token and continue to the end of the line.</p>
 
-      <pre id="ex-simple-triple" class="example N-Triples" data-transform="updateExample"
+      <pre id="ex-simple-triple" class="example ntriples" data-transform="updateExample"
            title="Simple Triple">
         <!--
         <http://example.org/#spiderman> <http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/#green-goblin> .
@@ -172,7 +172,8 @@
 
       <p>A <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>
         may be the <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
-        <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of a triple.</p>
+        <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of an
+        <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF triple</a>.</p>
 
       <p>A <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>
         is represented as a <code><a href="#grammar-production-quotedTriple">quotedTriple</a></code> with
@@ -180,16 +181,15 @@
         <code><a href="#grammar-production-predicate">predicate</a></code>, and
         <code><a href="#grammar-production-object">object</a></code>
         proceeded by `&lt;&lt;` and followed by `>>`.
-        Note that <a data-cite="RDF12-CONCEPTS#dfn-complex-triple">complex triples</a>
+        Note that <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</a>
         may be recursive.
        </p>
 
-      <pre id="ex-quoted-triple" class="example quoted triple" data-transform="updateExample"
+      <pre id="ex-quoted-triple" class="example ntriples" data-transform="updateExample"
            title="Quoted Triple">
         <!--
-        <http://example.org/employee38> <http://example.org/familyName> "Smith" .
-        << <http://example.org/jobTitle> <http://example.org/jobTitle> "Assistant Designer" >>
-           <http://example.org/accordingTo> <http://example.org/employee22> .
+        _:e38 <ex:familyName> "Smith" .
+        << _:e38 <http://example.com/jobTitle> "Designer" >> <http://example.com/accordingTo> _:e22 .
         -->
       </pre>
     </section>
@@ -240,29 +240,17 @@
       </p>
 
 
-      <pre id="ex-literals" class="example ntriples"
+      <pre id="ex-literals" class="example ntriples" data-transform="updateExample"
            title="Literals in N-Triples">
-        &lt;http://example.org/show/218&gt;
-          &lt;http://www.w3.org/2000/01/rdf-schema#label&gt;
-            &quot;That Seventies Show&quot;^^&lt;http://www.w3.org/2001/XMLSchema#string&gt; . # literal with XML Schema string datatype&#x2424;
-        &lt;http://example.org/show/218&gt;
-          &lt;http://www.w3.org/2000/01/rdf-schema#label&gt;
-            &quot;That Seventies Show&quot; . # same as above&#x2424;
-        &lt;http://example.org/show/218&gt;
-          &lt;http://example.org/show/localName&gt;
-            &quot;That Seventies Show&quot;@en . # literal with a language tag&#x2424;
-        &lt;http://example.org/show/218&gt;
-          &lt;http://example.org/show/localName&gt;
-            &quot;Cette S&eacute;rie des Ann&eacute;es Septante&quot;@fr-be .  # literal outside of ASCII range with a region subtag&#x2424;
-        &lt;http://example.org/#spiderman&gt;
-          &lt;http://example.org/text&gt;
-            &quot;This is a multi-linenliteral with many quotes (&quot;&quot;&quot;&quot;&quot;)nand two apostrophes (&#x27;&#x27;).&quot; .&#x2424;
-        &lt;http://en.wikipedia.org/wiki/Helium&gt;
-          &lt;http://example.org/elements/atomicNumber&gt;
-            &quot;2&quot;^^&lt;http://www.w3.org/2001/XMLSchema#integer&gt; . # xsd:integer&#x2424;
-        &lt;http://en.wikipedia.org/wiki/Helium&gt;
-          &lt;http://example.org/elements/specificGravity&gt;
-            &quot;1.663E-4&quot;^^&lt;http://www.w3.org/2001/XMLSchema#double&gt; .     # xsd:double&#x2424;
+        <!--
+        <http://example.org/show/218> <http://www.w3.org/2000/01/rdf-schema#label> "That Seventies Show"^^<http://www.w3.org/2001/XMLSchema#string> . # literal with XML Schema string datatype
+        <http://example.org/show/218> <http://www.w3.org/2000/01/rdf-schema#label> "That Seventies Show" . # same as above
+        <http://example.org/show/218> <http://example.org/show/localName> "That Seventies Show"@en . # literal with a language tag
+        <http://example.org/show/218> <http://example.org/show/localName> "Cette Série des Années Septante"@fr-be .  # literal outside of ASCII range with a region subtag
+        <http://example.org/#spiderman> <http://example.org/text> "This is a multi-linenliteral with many quotes (""""")nand two apostrophes ('')." .
+        <http://en.wikipedia.org/wiki/Helium> <http://example.org/elements/atomicNumber> "2"^^<http://www.w3.org/2001/XMLSchema#integer> . # xsd:integer
+        <http://en.wikipedia.org/wiki/Helium> <http://example.org/elements/specificGravity> "1.663E-4"^^<http://www.w3.org/2001/XMLSchema#double> .     # xsd:double
+        -->
       </pre>
     </section>
 
@@ -281,10 +269,12 @@
         A fresh RDF blank node is allocated for each unique blank node label in a document.
         Repeated use of the same blank node label identifies the same RDF blank node.
       </p>
-      <pre id="ex-bnodes" class="example ntriples"
+      <pre id="ex-bnodes" class="example ntriples" data-transform="updateExample"
            title="Blank nodes in N-Triples">
-        _:alice &lt;http://xmlns.com/foaf/0.1/knows&gt; _:bob .&#x2424;
-        _:bob &lt;http://xmlns.com/foaf/0.1/knows&gt; _:alice .&#x2424;
+        <!--
+        _:alice <http://xmlns.com/foaf/0.1/knows> _:bob .
+        _:bob <http://xmlns.com/foaf/0.1/knows> _:alice .
+        -->
       </pre>
     </section>
   </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -188,7 +188,7 @@
       <pre id="ex-quoted-triple" class="example ntriples" data-transform="updateExample"
            title="Quoted Triple">
         <!--
-        _:e38 <ex:familyName> "Smith" .
+        _:e38                                                <ex:familyName>                  "Smith" .
         << _:e38 <http://example.com/jobTitle> "Designer" >> <http://example.com/accordingTo> _:e22 .
         -->
       </pre>
@@ -273,7 +273,7 @@
            title="Blank nodes in N-Triples">
         <!--
         _:alice <http://xmlns.com/foaf/0.1/knows> _:bob .
-        _:bob <http://xmlns.com/foaf/0.1/knows> _:alice .
+        _:bob   <http://xmlns.com/foaf/0.1/knows> _:alice .
         -->
       </pre>
     </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -61,6 +61,14 @@
 <body>
   <section id='abstract'>
     <p>N-Triples is a line-based, plain text format for encoding an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a>.</p>
+
+    <p>RDF 1.2 N-Triples introduces <a data-cite="RDF12-CONCEPTS#dfn-quoted-triples">quoted triples</a>
+      as a fourth kind of <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF term</a>
+      which can be used as the
+      <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
+      <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of another
+      <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a>,
+      making it possible to make statements about other statements.</p>
   </section>
 
   <section id='sotd'>
@@ -151,10 +159,37 @@
       <p>Comments are treated as white space, and may be given after a '<code>#</code>' that is not part of
         another lexical token and continue to the end of the line.</p>
 
-      <pre id="ex-simple-triple" class="example ntriples" data-transform="updateExample"
+      <pre id="ex-simple-triple" class="example N-Triples" data-transform="updateExample"
            title="Simple Triple">
         <!--
         <http://example.org/#spiderman> <http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/#green-goblin> .
+        -->
+      </pre>
+    </section>
+
+    <section id="quoted-triples">
+      <h3>Quoted Triples</h3>
+
+      <p>A <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>
+        may be the <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
+        <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of a triple.</p>
+
+      <p>A <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>
+        is represented as a <code><a href="#grammar-production-quotedTriple">quotedTriple</a></code> with
+        <code><a href="#grammar-production-subject">subject</a></code>,
+        <code><a href="#grammar-production-predicate">predicate</a></code>, and
+        <code><a href="#grammar-production-object">object</a></code>
+        proceeded by `&lt;&lt;` and followed by `>>`.
+        Note that <a data-cite="RDF12-CONCEPTS#dfn-complex-triple">complex triples</a>
+        may be recursive.
+       </p>
+
+      <pre id="ex-quoted-triple" class="example quoted triple" data-transform="updateExample"
+           title="Quoted Triple">
+        <!--
+        <http://example.org/employee38> <http://example.org/familyName> "Smith" .
+        << <http://example.org/jobTitle> <http://example.org/jobTitle> "Assistant Designer" >>
+           <http://example.org/accordingTo> <http://example.org/employee22> .
         -->
       </pre>
     </section>
@@ -401,17 +436,97 @@
 
     <section id="sec-parsing-terms">
       <h3>RDF Term Constructors</h3>
-      <p>This table maps productions and lexical tokens to <code>RDF terms</code> or components of <code>RDF terms</code> listed in <a class="sectionRef sec-ref" href="#sec-parsing">section </a>:</p>
+      <p>This table maps productions and lexical tokens to <code>RDF terms</code> or components of <code>RDF terms</code> listed in <a class="sectionRef sec-ref" href="#sec-parsing"></a>:</p>
       <table class="simple">
         <thead>
           <tr><th>production</th><th>type</th><th>procedure</th></tr>
         </thead>
         <tbody>
-          <tr id="handle-IRIREF"><td style="text-align:left;"><a href="#grammar-production-IRIREF" class="type IRI">IRIREF</a></td><td><a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a></td><td>The characters between &quot;&lt;&quot; and &quot;&gt;&quot; are taken, with escape sequences unescaped, to form the unicode string of the IRI.</td></tr>
-          <tr id="handle-STRING_LITERAL_QUOTE"><td style="text-align:left;"><a href="#grammar-production-STRING_LITERAL_QUOTE" class="type lexicalForm">STRING_LITERAL_QUOTE</a></td><td><a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a></td><td>The characters between the outermost '&quot;'s   are taken, with escape sequences unescaped, to form the unicode string of a lexical form.</td></tr>
-          <tr id="handle-LANGTAG"><td style="text-align:left;"><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></td><td><a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a></td><td>The characters following the <code>@</code> form the unicode string of the language tag.</td></tr>
-          <tr id="handle-literal"><td style="text-align:left;"><a href="#grammar-production-literal" class="type literal">literal</a></td><td><a data-cite="RDF12-CONCEPTS#dfn-literal">literal</a></td><td>The literal has a lexical form of the first rule argument, <code>   STRING_LITERAL_QUOTE</code>, and either a language tag of <code>LANGTAG</code> or a datatype IRI of <code>iri</code>, depending on which rule matched the input.  If the <code>LANGTAG</code> rule matched, the datatype is <code>rdf:langString</code> and the language tag is <code>LANGTAG</code>. If neither a language tag nor a datatype IRI is provided, the literal has a datatype of <code>xsd:string</code>.</td></tr>
-          <tr id="handle-BLANK_NODE_LABEL"><td style="text-align:left;"><a href="#grammar-production-BLANK_NODE_LABEL" class="type bNode">BLANK_NODE_LABEL</a></td><td><a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a></td><td>The string after '<code>_:</code>', is a key in <a href="#bnodeLabels">bnodeLabels</a>. If there is no corresponding blank node in the map, one is allocated.</td></tr>
+          <tr id="handle-BLANK_NODE_LABEL">
+            <td style="text-align:left;">
+              <a href="#grammar-production-BLANK_NODE_LABEL" class="type bNode">BLANK_NODE_LABEL</a>
+            </td>
+            <td>
+              <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>
+            </td>
+            <td>
+              The string after '<code>_:</code>',
+              is a key in <a href="#bnodeLabels">bnodeLabels</a>.
+              If there is no corresponding blank node in the map,
+              one is allocated.
+            </td>
+          </tr>
+          <tr id="handle-IRIREF">
+            <td style="text-align:left;">
+              <a href="#grammar-production-IRIREF" class="type IRI">IRIREF</a>
+            </td>
+            <td>
+              <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a>
+            </td>
+            <td>
+              The characters between &quot;&lt;&quot; and &quot;&gt;&quot; are taken,
+              with escape sequences unescaped,
+              to form the unicode string of the IRI.
+            </td>
+          </tr>
+          <tr id="handle-LANGTAG">
+            <td style="text-align:left;">
+              <a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a>
+            </td>
+            <td>
+              <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
+            </td>
+            <td>
+              The characters following the <code>@</code> form the unicode string of the language tag.
+            </td>
+          </tr>
+          <tr id="handle-STRING_LITERAL_QUOTE">
+            <td style="text-align:left;">
+              <a href="#grammar-production-STRING_LITERAL_QUOTE" class="type lexicalForm">STRING_LITERAL_QUOTE</a>
+            </td>
+            <td>
+              <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a>
+            </td>
+            <td>
+              The characters between the outermost '&quot;'s are taken,
+              with escape sequences unescaped,
+              to form the unicode string of a lexical form.
+            </td>
+          </tr>
+          <tr id="handle-literal">
+            <td style="text-align:left;">
+              <a href="#grammar-production-literal" class="type literal">literal</a>
+            </td>
+            <td><a data-cite="RDF12-CONCEPTS#dfn-literal">literal</a>
+            </td>
+            <td>
+              The literal has a lexical form of the first rule argument,
+              <code>STRING_LITERAL_QUOTE</code>,
+              and either a language tag of <code>LANGTAG</code>
+              or a datatype IRI of <code>iri</code>,
+              depending on which rule matched the input.
+              If the <code>LANGTAG</code> rule matched,
+              the datatype is <code>rdf:langString</code>
+              and the language tag is <code>LANGTAG</code>.
+              If neither a language tag nor a datatype IRI is provided,
+              the literal has a datatype of <code>xsd:string</code>.
+            </td>
+          </tr>
+          <tr id="handle-quotedTriple">
+            <td style="text-align:left;">
+              <a href="#grammar-production-quotedTriple" class="type quotedTriple">quotedTriple</a>
+            </td>
+            <td>
+              <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>
+            </td>
+            <td>
+              The <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>
+              is composed of the terms constructed from
+              the <code><a href="#grammar-production-subject">subject</a></code>,
+              <code><a href="#grammar-production-predicate">predicate</a></code>, and
+              <code><a href="#grammar-production-object">object</a></code> productions.
+            </td>
+          </tr>
         </tbody>
       </table>
     </section>
@@ -591,6 +706,9 @@
       better mirroring [[RDF12-TURTLE]].</li>
     <li>Updated the <a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a>
       grammar production to be consisten with with Turtle.</li>
+   <li>Adds support for <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</a>
+      as described in <a href="#quoted-triples" class="sectionRef"></a>
+      with updates to <a href="#sec-parsing-terms" class="sectionRef"></a>.</li>
     <li>Separated <a href="#security"></a> from <a href="#sec-mediaReg-n-triples"></a>
       and updated language.</li>
     <li>Changes <a href="#canonical-ntriples"></a> to clarify

--- a/spec/index.html
+++ b/spec/index.html
@@ -180,7 +180,7 @@
         <code><a href="#grammar-production-subject">subject</a></code>,
         <code><a href="#grammar-production-predicate">predicate</a></code>, and
         <code><a href="#grammar-production-object">object</a></code>
-        proceeded by `&lt;&lt;` and followed by `>>`.
+        proceeded by <code>&lt;&lt;</code> and followed by <code>&gt;&gt;</code>.
         Note that <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</a>
         may be recursive.
        </p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -180,7 +180,7 @@
         <code><a href="#grammar-production-subject">subject</a></code>,
         <code><a href="#grammar-production-predicate">predicate</a></code>, and
         <code><a href="#grammar-production-object">object</a></code>
-        proceeded by <code>&lt;&lt;</code> and followed by <code>&gt;&gt;</code>.
+        preceded by <code>&lt;&lt;</code> and followed by <code>&gt;&gt;</code>.
         Note that <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</a>
         may be recursive.
        </p>
@@ -488,7 +488,7 @@
               <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a>
             </td>
             <td>
-              The characters between the outermost '&quot;'s are taken,
+              The characters between the outermost quotation marks (<code>&quot;</code>) are taken,
               with escape sequences unescaped,
               to form the unicode string of a lexical form.
             </td>

--- a/spec/index.html
+++ b/spec/index.html
@@ -240,17 +240,29 @@
       </p>
 
 
-      <pre id="ex-literals" class="example ntriples" data-transform="updateExample"
+      <pre id="ex-literals" class="example ntriples"
            title="Literals in N-Triples">
-        <!--
-        <http://example.org/show/218> <http://www.w3.org/2000/01/rdf-schema#label> "That Seventies Show"^^<http://www.w3.org/2001/XMLSchema#string> . # literal with XML Schema string datatype
-        <http://example.org/show/218> <http://www.w3.org/2000/01/rdf-schema#label> "That Seventies Show" . # same as above
-        <http://example.org/show/218> <http://example.org/show/localName> "That Seventies Show"@en . # literal with a language tag
-        <http://example.org/show/218> <http://example.org/show/localName> "Cette Série des Années Septante"@fr-be .  # literal outside of ASCII range with a region subtag
-        <http://example.org/#spiderman> <http://example.org/text> "This is a multi-linenliteral with many quotes (""""")nand two apostrophes ('')." .
-        <http://en.wikipedia.org/wiki/Helium> <http://example.org/elements/atomicNumber> "2"^^<http://www.w3.org/2001/XMLSchema#integer> . # xsd:integer
-        <http://en.wikipedia.org/wiki/Helium> <http://example.org/elements/specificGravity> "1.663E-4"^^<http://www.w3.org/2001/XMLSchema#double> .     # xsd:double
-        -->
+        &lt;http://example.org/show/218&gt;
+          &lt;http://www.w3.org/2000/01/rdf-schema#label&gt;
+            &quot;That Seventies Show&quot;^^&lt;http://www.w3.org/2001/XMLSchema#string&gt; . # literal with XML Schema string datatype&#x2424;
+        &lt;http://example.org/show/218&gt;
+          &lt;http://www.w3.org/2000/01/rdf-schema#label&gt;
+            &quot;That Seventies Show&quot; . # same as above&#x2424;
+        &lt;http://example.org/show/218&gt;
+          &lt;http://example.org/show/localName&gt;
+            &quot;That Seventies Show&quot;@en . # literal with a language tag&#x2424;
+        &lt;http://example.org/show/218&gt;
+          &lt;http://example.org/show/localName&gt;
+            &quot;Cette S&eacute;rie des Ann&eacute;es Septante&quot;@fr-be .  # literal outside of ASCII range with a region subtag&#x2424;
+        &lt;http://example.org/#spiderman&gt;
+          &lt;http://example.org/text&gt;
+            &quot;This is a multi-linenliteral with many quotes (&quot;&quot;&quot;&quot;&quot;)nand two apostrophes (&#x27;&#x27;).&quot; .&#x2424;
+        &lt;http://en.wikipedia.org/wiki/Helium&gt;
+          &lt;http://example.org/elements/atomicNumber&gt;
+            &quot;2&quot;^^&lt;http://www.w3.org/2001/XMLSchema#integer&gt; . # xsd:integer&#x2424;
+        &lt;http://en.wikipedia.org/wiki/Helium&gt;
+          &lt;http://example.org/elements/specificGravity&gt;
+            &quot;1.663E-4&quot;^^&lt;http://www.w3.org/2001/XMLSchema#double&gt; .     # xsd:double&#x2424;
       </pre>
     </section>
 
@@ -269,12 +281,10 @@
         A fresh RDF blank node is allocated for each unique blank node label in a document.
         Repeated use of the same blank node label identifies the same RDF blank node.
       </p>
-      <pre id="ex-bnodes" class="example ntriples" data-transform="updateExample"
+      <pre id="ex-bnodes" class="example ntriples"
            title="Blank nodes in N-Triples">
-        <!--
-        _:alice <http://xmlns.com/foaf/0.1/knows> _:bob .
-        _:bob <http://xmlns.com/foaf/0.1/knows> _:alice .
-        -->
+        _:alice &lt;http://xmlns.com/foaf/0.1/knows&gt; _:bob .&#x2424;
+        _:bob &lt;http://xmlns.com/foaf/0.1/knows&gt; _:alice .&#x2424;
       </pre>
     </section>
   </section>

--- a/spec/ntriples-bnf.html
+++ b/spec/ntriples-bnf.html
@@ -1,107 +1,184 @@
-<table  class="grammar">
-  <tbody class="grammar-productions">
-    <tr id="grammar-production-ntriplesDoc" data-grammar-original="[1]  ntriplesDoc        ::= triple? (EOL triple)* EOL?" data-grammar-expression="(&#x27;,&#x27;, [(&#x27;?&#x27;, (&#x27;id&#x27;, &#x27;triple&#x27;)), (&#x27;*&#x27;, (&#x27;,&#x27;, [(&#x27;id&#x27;, &#x27;EOL&#x27;), (&#x27;id&#x27;, &#x27;triple&#x27;)])), (&#x27;?&#x27;, (&#x27;id&#x27;, &#x27;EOL&#x27;))])" >
+
+<table class="grammar">
+  <tbody id="grammar-productions" class="ebnf">
+    <tr id="grammar-production-ntriplesDoc">
       <td>[1]</td>
       <td><code>ntriplesDoc</code></td>
       <td>::=</td>
-      <td><a href='#grammar-production-triple'>triple</a>? (<a href='#grammar-production-EOL'>EOL</a> <a href='#grammar-production-triple'>triple</a>)<code class='grammar-star'>*</code> <a href='#grammar-production-EOL'>EOL</a>?</td>
+      <td><a href="#grammar-production-triple">triple</a><code>?</code>  <code>(</code> <a href="#grammar-production-EOL">EOL</a> <a href="#grammar-production-triple">triple</a><code>)</code> <code>*</code>  <a href="#grammar-production-EOL">EOL</a><code>?</code> </td>
     </tr>
-    <tr id="grammar-production-triple" data-grammar-original="[2]  triple             ::= subject predicate object &#x27;.&#x27;" data-grammar-expression="(&#x27;,&#x27;, [(&#x27;id&#x27;, &#x27;subject&#x27;), (&#x27;id&#x27;, &#x27;predicate&#x27;), (&#x27;id&#x27;, &#x27;object&#x27;), (&quot;&#x27;&quot;, &#x27;.&#x27;)])" >
+    <tr id="grammar-production-triple">
       <td>[2]</td>
       <td><code>triple</code></td>
       <td>::=</td>
-      <td><a href='#grammar-production-subject'>subject</a> <a href='#grammar-production-predicate'>predicate</a> <a href='#grammar-production-object'>object</a> '<code class='grammar-literal'>.</code>'</td>
+      <td><a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> "<code class="grammar-literal">.</code>"</td>
     </tr>
-    <tr id="grammar-production-subject" data-grammar-original="[3]  subject            ::= IRIREF | BLANK_NODE_LABEL" data-grammar-expression="(&#x27;|&#x27;, [(&#x27;id&#x27;, &#x27;IRIREF&#x27;), (&#x27;id&#x27;, &#x27;BLANK_NODE_LABEL&#x27;)])" >
+    <tr id="grammar-production-subject">
       <td>[3]</td>
       <td><code>subject</code></td>
       <td>::=</td>
-      <td><a href='#grammar-production-IRIREF'>IRIREF</a> <code>| </code> <a href='#grammar-production-BLANK_NODE_LABEL'>BLANK_NODE_LABEL</a></td>
+      <td><a href="#grammar-production-IRIREF">IRIREF</a> <code>|</code> <a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code>|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
     </tr>
-    <tr id="grammar-production-predicate" data-grammar-original="[4]  predicate          ::= IRIREF" data-grammar-expression="(&#x27;id&#x27;, &#x27;IRIREF&#x27;)" >
+    <tr id="grammar-production-predicate">
       <td>[4]</td>
       <td><code>predicate</code></td>
       <td>::=</td>
-      <td><a href='#grammar-production-IRIREF'>IRIREF</a></td>
+      <td><a href="#grammar-production-IRIREF">IRIREF</a></td>
     </tr>
-    <tr id="grammar-production-object" data-grammar-original="[5]  object             ::= IRIREF | BLANK_NODE_LABEL | literal" data-grammar-expression="(&#x27;|&#x27;, [(&#x27;id&#x27;, &#x27;IRIREF&#x27;), (&#x27;id&#x27;, &#x27;BLANK_NODE_LABEL&#x27;), (&#x27;id&#x27;, &#x27;literal&#x27;)])" >
+    <tr id="grammar-production-object">
       <td>[5]</td>
       <td><code>object</code></td>
       <td>::=</td>
-      <td><a href='#grammar-production-IRIREF'>IRIREF</a> <code>| </code> <a href='#grammar-production-BLANK_NODE_LABEL'>BLANK_NODE_LABEL</a> <code>| </code> <a href='#grammar-production-literal'>literal</a></td>
+      <td><a href="#grammar-production-IRIREF">IRIREF</a> <code>|</code> <a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code>|</code> <a href="#grammar-production-literal">literal</a> <code>|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
     </tr>
-    <tr id="grammar-production-literal" data-grammar-original="[6]  literal            ::= STRING_LITERAL_QUOTE (&#x27;^^&#x27; IRIREF | LANGTAG )?" data-grammar-expression="(&#x27;,&#x27;, [(&#x27;id&#x27;, &#x27;STRING_LITERAL_QUOTE&#x27;), (&#x27;?&#x27;, (&#x27;|&#x27;, [(&#x27;,&#x27;, [(&quot;&#x27;&quot;, &#x27;^^&#x27;), (&#x27;id&#x27;, &#x27;IRIREF&#x27;)]), (&#x27;,&#x27;, [&#x27;id&#x27;, &#x27;LANGTAG&#x27;)])]))])" >
+    <tr id="grammar-production-literal">
       <td>[6]</td>
       <td><code>literal</code></td>
       <td>::=</td>
-      <td><a href='#grammar-production-STRING_LITERAL_QUOTE'>STRING_LITERAL_QUOTE</a> ('<code class='grammar-literal'>^^</code>' <a href='#grammar-production-IRIREF'>IRIREF</a> <code>| </code> <a href='#grammar-production-LANGTAG'>LANGTAG</a>)?</td>
+      <td><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a> <code>(</code> <code>(</code> &quot;^^&quot; <a href="#grammar-production-IRIREF">IRIREF</a><code>)</code>  <code>|</code> <a href="#grammar-production-LANGTAG">LANGTAG</a><code>)</code> <code>?</code> </td>
     </tr>
-    <tr><td colspan="4"><h4 id="terminals">Productions for terminals</h4></td></tr>
-    <tr id="grammar-production-LANGTAG" data-grammar-original="[144s] LANGTAG          ::= &quot;@&quot; [a-zA-Z]+ ( &quot;-&quot; [a-zA-Z0-9]+ )*" data-grammar-expression="(&#x27;,&#x27;, [(&quot;&#x27;&quot;, &#x27;@&#x27;), (&#x27;+&#x27;, (&#x27;[&#x27;, &#x27;a-zA-Z&#x27;)), (&#x27;*&#x27;, (&#x27;,&#x27;, [(&quot;&#x27;&quot;, &#x27;-&#x27;), (&#x27;+&#x27;, (&#x27;[&#x27;, &#x27;a-zA-Z0-9&#x27;))]))])" class='grammar-token'>
-      <td>[144s]</td>
-      <td><code>LANGTAG</code></td>
-      <td>::=</td>
-      <td>'<code class='grammar-literal'>@</code>' [<code class='grammar-chars'>a-zA-Z</code>]<code class='grammar-plus'>+</code> ('<code class='grammar-literal'>-</code>' [<code class='grammar-chars'>a-zA-Z0-9</code>]<code class='grammar-plus'>+</code>)<code class='grammar-star'>*</code></td>
-    </tr>
-    <tr id="grammar-production-EOL" data-grammar-original="[7]  EOL                ::= [#xD#xA]+" data-grammar-expression="(&#x27;+&#x27;, (&#x27;[&#x27;, &#x27;#xD#xA&#x27;))" class='grammar-token'>
+    <tr id="grammar-production-quotedTriple">
       <td>[7]</td>
-      <td><code>EOL</code></td>
+      <td><code>quotedTriple</code></td>
       <td>::=</td>
-      <td>[<code class='grammar-chars'>#xD#xA</code>]<code class='grammar-plus'>+</code></td>
+      <td>&quot;&lt;&lt;&quot; <a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> &quot;&gt;&gt;&quot;</td>
     </tr>
-    <tr id="grammar-production-IRIREF" data-grammar-original="[8] IRIREF ::=  &#x27;&lt;&#x27; ([^#x00-#x20&lt;&gt;&quot;{}|^`\] | UCHAR)* &#x27;&gt;&#x27;" data-grammar-expression="(&#x27;,&#x27;, [(&quot;&#x27;&quot;, &#x27;&lt;&#x27;), (&#x27;*&#x27;, (&#x27;|&#x27;, [(&#x27;[&#x27;, &#x27;^#x00-#x20&lt;&gt;&quot;{}|^`\\&#x27;), (&#x27;id&#x27;, &#x27;UCHAR&#x27;)])), (&quot;&#x27;&quot;, &#x27;&gt;&#x27;)])" class='grammar-token'>
-      <td>[8]</td>
+    <tr>
+      <td colspan=2>@terminals</td>
+      <td></td>
+      <td><strong># Productions for terminals</strong></td>
+    </tr>
+    <tr id="grammar-production-IRIREF">
+      <td>[9]</td>
       <td><code>IRIREF</code></td>
       <td>::=</td>
-      <td>'<code class='grammar-literal'>&lt;</code>' ([<code class='grammar-chars'>^#x00-#x20&lt;&gt;&quot;{}|^`\</code>] <code>| </code> <a href='#grammar-production-UCHAR'>UCHAR</a>)<code class='grammar-star'>*</code> '<code class='grammar-literal'>&gt;</code>'</td>
+      <td>"<code class="grammar-literal">&lt;</code>" <code>[</code> <code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&lt;&gt;&quot;{}|^`]</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">|</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">UCHAR)*</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&apos;&gt;&apos;</code><code>]</code> </td>
     </tr>
-    <tr id="grammar-production-STRING_LITERAL_QUOTE" data-grammar-original="[9] STRING_LITERAL_QUOTE ::= &#x27;&quot;&#x27; ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* &#x27;&quot;&#x27;" data-grammar-expression="(&#x27;,&#x27;, [(&quot;&#x27;&quot;, &#x27;&quot;&#x27;), (&#x27;*&#x27;, (&#x27;|&#x27;, [(&#x27;[&#x27;, &#x27;^#x22#x5C#xA#xD&#x27;), (&#x27;id&#x27;, &#x27;ECHAR&#x27;), (&#x27;id&#x27;, &#x27;UCHAR&#x27;)])), (&quot;&#x27;&quot;, &#x27;&quot;&#x27;)])" class='grammar-token'>
-      <td>[9]</td>
-      <td><code>STRING_LITERAL_QUOTE</code></td>
-      <td>::=</td>
-      <td>'<code class='grammar-literal'>&quot;</code>' ([<code class='grammar-chars'>^#x22#x5C#xA#xD</code>] <code>| </code> <a href='#grammar-production-ECHAR'>ECHAR</a> <code>| </code> <a href='#grammar-production-UCHAR'>UCHAR</a>)<code class='grammar-star'>*</code> '<code class='grammar-literal'>&quot;</code>'</td>
-    </tr>
-    <tr id="grammar-production-BLANK_NODE_LABEL" data-grammar-original="[141s] BLANK_NODE_LABEL ::= &#x27;_:&#x27; ( PN_CHARS_U | [0-9] ) ((PN_CHARS|&#x27;.&#x27;)* PN_CHARS)?" data-grammar-expression="(&#x27;,&#x27;, [(&quot;&#x27;&quot;, &#x27;_:&#x27;), (&#x27;|&#x27;, [(&#x27;id&#x27;, &#x27;PN_CHARS_U&#x27;), (&#x27;[&#x27;, &#x27;0-9&#x27;)]), (&#x27;?&#x27;, (&#x27;,&#x27;, [(&#x27;*&#x27;, (&#x27;|&#x27;, [(&#x27;id&#x27;, &#x27;PN_CHARS&#x27;), (&quot;&#x27;&quot;, &#x27;.&#x27;)])), (&#x27;id&#x27;, &#x27;PN_CHARS&#x27;)]))])" class='grammar-token'>
-      <td>[141s]</td>
+    <tr id="grammar-production-BLANK_NODE_LABEL">
+      <td>[10]</td>
       <td><code>BLANK_NODE_LABEL</code></td>
       <td>::=</td>
-      <td>'<code class='grammar-literal'>_:</code>' (<a href='#grammar-production-PN_CHARS_U'>PN_CHARS_U</a> <code>| </code> [<code class='grammar-chars'>0-9</code>]) ((<a href='#grammar-production-PN_CHARS'>PN_CHARS</a> <code>| </code> '<code class='grammar-literal'>.</code>')<code class='grammar-star'>*</code> <a href='#grammar-production-PN_CHARS'>PN_CHARS</a>)?</td>
+      <td>&quot;_:&quot; <code>(</code> <a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code>|</code> <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>)</code>  <code>(</code> <code>(</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code>|</code> "<code class="grammar-literal">.</code>"<code>)</code> <code>*</code>  <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code>)</code> <code>?</code> </td>
     </tr>
-    <tr id="grammar-production-UCHAR" data-grammar-original="[10] UCHAR ::= ( &quot;\u&quot; HEX HEX HEX HEX )| ( &quot;\U&quot; HEX HEX HEX HEX HEX HEX HEX HEX )" data-grammar-expression="(&#x27;|&#x27;, [(&#x27;,&#x27;, [(&quot;&#x27;&quot;, &#x27;\\u&#x27;), (&#x27;id&#x27;, &#x27;HEX&#x27;), (&#x27;id&#x27;, &#x27;HEX&#x27;), (&#x27;id&#x27;, &#x27;HEX&#x27;), (&#x27;id&#x27;, &#x27;HEX&#x27;)]), (&#x27;,&#x27;, [(&quot;&#x27;&quot;, &#x27;\\U&#x27;), (&#x27;id&#x27;, &#x27;HEX&#x27;), (&#x27;id&#x27;, &#x27;HEX&#x27;), (&#x27;id&#x27;, &#x27;HEX&#x27;), (&#x27;id&#x27;, &#x27;HEX&#x27;), (&#x27;id&#x27;, &#x27;HEX&#x27;), (&#x27;id&#x27;, &#x27;HEX&#x27;), (&#x27;id&#x27;, &#x27;HEX&#x27;), (&#x27;id&#x27;, &#x27;HEX&#x27;)])])" class='grammar-token'>
-      <td>[10]</td>
+    <tr id="grammar-production-LANGTAG">
+      <td>[11]</td>
+      <td><code>LANGTAG</code></td>
+      <td>::=</td>
+      <td>"<code class="grammar-literal">@</code>" <code>[</code> <code class="grammar-literal">a-zA-Z</code><code>]</code> <code>+</code>  <code>(</code> "<code class="grammar-literal">-</code>" <code>[</code> <code class="grammar-literal">a-zA-Z0-9</code><code>]</code> <code>+</code> <code>)</code> <code>*</code> </td>
+    </tr>
+    <tr id="grammar-production-STRING_LITERAL_QUOTE">
+      <td>[12]</td>
+      <td><code>STRING_LITERAL_QUOTE</code></td>
+      <td>::=</td>
+      <td>'<code class="grammar-literal">&quot;</code>' <code>(</code> <code>[</code> <code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="quot">>&quot;</abbr></code><code class="grammar-char-escape"><abbr title="ascii '\'">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code>]</code>  <code>|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code>|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code>)</code> <code>*</code>  '<code class="grammar-literal">&quot;</code>'</td>
+    </tr>
+    <tr id="grammar-production-UCHAR">
+      <td>[13]</td>
       <td><code>UCHAR</code></td>
       <td>::=</td>
-      <td>'<code class='grammar-literal'>\u</code>' <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <code>| </code> '<code class='grammar-literal'>\U</code>' <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a></td>
+      <td><code>(</code> "<code class="grammar-literal">u</code>" <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code>)</code>  <code>|</code> <code>(</code> "<code class="grammar-literal">U</code>" <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code>)</code> </td>
     </tr>
-    <tr id="grammar-production-ECHAR" data-grammar-original="[153s] ECHAR ::= &quot;\&quot; [tbnrf&quot;\]" data-grammar-expression="(&#x27;,&#x27;, [(&quot;&#x27;&quot;, &#x27;\\&#x27;), (&#x27;[&#x27;, &#x27;tbnrf&quot;\&#x27;&#x27;)])" class='grammar-token'>
-      <td>[153s]</td>
+    <tr id="grammar-production-ECHAR">
+      <td>[14]</td>
       <td><code>ECHAR</code></td>
       <td>::=</td>
-      <td>'<code class='grammar-literal'>\</code>' [<code class='grammar-chars'>tbnrf&quot;&#x27;\</code>]</td>
+      <td>"<code class="grammar-literal">\</code>" <code>[</code> <code class="grammar-literal">tbnrf&quot;&apos;</code><code>]</code> </td>
     </tr>
-    <tr id="grammar-production-PN_CHARS_BASE" data-grammar-original="[157s] PN_CHARS_BASE    ::= [A-Z]| [a-z]| [#x00C0-#x00D6]| [#x00D8-#x00F6]| [#x00F8-#x02FF]| [#x0370-#x037D]| [#x037F-#x1FFF]| [#x200C-#x200D]| [#x2070-#x218F]| [#x2C00-#x2FEF]| [#x3001-#xD7FF]| [#xF900-#xFDCF]| [#xFDF0-#xFFFD]| [#x10000-#xEFFFF]" data-grammar-expression="(&#x27;|&#x27;, [(&#x27;[&#x27;, &#x27;A-Z&#x27;), (&#x27;[&#x27;, &#x27;a-z&#x27;), (&#x27;[&#x27;, &#x27;#x00C0-#x00D6&#x27;), (&#x27;[&#x27;, &#x27;#x00D8-#x00F6&#x27;), (&#x27;[&#x27;, &#x27;#x00F8-#x02FF&#x27;), (&#x27;[&#x27;, &#x27;#x0370-#x037D&#x27;), (&#x27;[&#x27;, &#x27;#x037F-#x1FFF&#x27;), (&#x27;[&#x27;, &#x27;#x200C-#x200D&#x27;), (&#x27;[&#x27;, &#x27;#x2070-#x218F&#x27;), (&#x27;[&#x27;, &#x27;#x2C00-#x2FEF&#x27;), (&#x27;[&#x27;, &#x27;#x3001-#xD7FF&#x27;), (&#x27;[&#x27;, &#x27;#xF900-#xFDCF&#x27;), (&#x27;[&#x27;, &#x27;#xFDF0-#xFFFD&#x27;), (&#x27;[&#x27;, &#x27;#x10000-#xEFFFF&#x27;)])" class='grammar-token'>
-      <td>[157s]</td>
+    <tr id="grammar-production-PN_CHARS_BASE">
+      <td>[15]</td>
       <td><code>PN_CHARS_BASE</code></td>
       <td>::=</td>
-      <td>[<code class='grammar-chars'>A-Z</code>] <code>| </code> [<code class='grammar-chars'>a-z</code>] <code>| </code> [<code class='grammar-chars'>#x00C0-#x00D6</code>] <code>| </code> [<code class='grammar-chars'>#x00D8-#x00F6</code>] <code>| </code> [<code class='grammar-chars'>#x00F8-#x02FF</code>] <code>| </code> [<code class='grammar-chars'>#x0370-#x037D</code>] <code>| </code> [<code class='grammar-chars'>#x037F-#x1FFF</code>] <code>| </code> [<code class='grammar-chars'>#x200C-#x200D</code>] <code>| </code> [<code class='grammar-chars'>#x2070-#x218F</code>] <code>| </code> [<code class='grammar-chars'>#x2C00-#x2FEF</code>] <code>| </code> [<code class='grammar-chars'>#x3001-#xD7FF</code>] <code>| </code> [<code class='grammar-chars'>#xF900-#xFDCF</code>] <code>| </code> [<code class='grammar-chars'>#xFDF0-#xFFFD</code>] <code>| </code> [<code class='grammar-chars'>#x10000-#xEFFFF</code>]</td>
+      <td><code>[</code> <code class="grammar-literal">A-Z</code><code>]</code></td>
     </tr>
-    <tr id="grammar-production-PN_CHARS_U" data-grammar-original="[164s] PN_CHARS_U       ::=  PN_CHARS_BASE| &#x27;_&#x27;" data-grammar-expression="(&#x27;|&#x27;, [(&#x27;id&#x27;, &#x27;PN_CHARS_BASE&#x27;), (&quot;&#x27;&quot;, &#x27;_&#x27;), (&quot;&#x27;&quot;, &#x27;:&#x27;)])" class='grammar-token'>
-      <td>[164s]</td>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-literal">a-z</code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="extended ascii '#xC0'">#xC0</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="extended ascii '#xD6'">#xD6</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="extended ascii '#xD8'">#xD8</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="extended ascii '#xF6'">#xF6</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="extended ascii '#xF8'">#xF8</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x02FF</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x0370</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x037D</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x037F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x1FFF</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Format'">#x200C</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Format'">#x200D</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2070</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x218F</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2C00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x2FEF</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x3001</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#xD7FF</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xF900</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFDCF</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFDF0</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFFFD</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x00010000</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Noncharacter'">#x000EFFFF</abbr></code><code>]</code> </td>
+    </tr>
+    <tr id="grammar-production-PN_CHARS_U">
+      <td>[16]</td>
       <td><code>PN_CHARS_U</code></td>
       <td>::=</td>
-      <td><a href='#grammar-production-PN_CHARS_BASE'>PN_CHARS_BASE</a> <code>| </code> '<code class='grammar-literal'>_</code>'</td>
+      <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code>|</code> "<code class="grammar-literal">_</code>"</td>
     </tr>
-    <tr id="grammar-production-PN_CHARS" data-grammar-original="[160s] PN_CHARS         ::= PN_CHARS_U| &quot;-&quot;| [0-9]| #x00B7| [#x0300-#x036F]| [#x203F-#x2040]" data-grammar-expression="(&#x27;|&#x27;, [(&#x27;id&#x27;, &#x27;PN_CHARS_U&#x27;), (&quot;&#x27;&quot;, &#x27;-&#x27;), (&#x27;[&#x27;, &#x27;0-9&#x27;), (&#x27;#&#x27;, &#x27;#x00B7&#x27;), (&#x27;[&#x27;, &#x27;#x0300-#x036F&#x27;), (&#x27;[&#x27;, &#x27;#x203F-#x2040&#x27;)])" class='grammar-token'>
-      <td>[160s]</td>
+    <tr id="grammar-production-PN_CHARS">
+      <td>[17]</td>
       <td><code>PN_CHARS</code></td>
       <td>::=</td>
-      <td><a href='#grammar-production-PN_CHARS_U'>PN_CHARS_U</a> <code>| </code> '<code class='grammar-literal'>-</code>' <code>| </code> [<code class='grammar-chars'>0-9</code>] <code>| </code> <code class='grammar-char-escape'>#x00B7</code> <code>| </code> [<code class='grammar-chars'>#x0300-#x036F</code>] <code>| </code> [<code class='grammar-chars'>#x203F-#x2040</code>]</td>
+      <td><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code>|</code> "<code class="grammar-literal">-</code>" <code>|</code> <code>[</code> <code class="grammar-literal">0-9</code><code>]</code>  <code>|</code> <code class="grammar-char-escape"><abbr title="extended ascii '#xB7'">#xB7</abbr></code> <code>|</code> <code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x0300</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x036F</abbr></code><code>]</code>  <code>|</code> <code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x203F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2040</abbr></code><code>]</code> </td>
     </tr>
-    <tr id="grammar-production-HEX" data-grammar-original="[162s] HEX              ::= [0-9] | [A-F] | [a-f]" data-grammar-expression="(&#x27;|&#x27;, [(&#x27;[&#x27;, &#x27;0-9&#x27;), (&#x27;[&#x27;, &#x27;A-F&#x27;), (&#x27;[&#x27;, &#x27;a-f&#x27;)])" class='grammar-token'>
-      <td>[162s]</td>
+    <tr id="grammar-production-HEX">
+      <td>[18]</td>
       <td><code>HEX</code></td>
       <td>::=</td>
-      <td>[<code class='grammar-chars'>0-9</code>] <code>| </code> [<code class='grammar-chars'>A-F</code>] <code>| </code> [<code class='grammar-chars'>a-f</code>]</td>
+      <td><code>[</code> <code class="grammar-literal">0-9</code><code>]</code>  <code>|</code> <code>[</code> <code class="grammar-literal">A-F</code><code>]</code>  <code>|</code> <code>[</code> <code class="grammar-literal">a-f</code><code>]</code> </td>
+    </tr>
+    <tr id="grammar-production-EOL">
+      <td>[19]</td>
+      <td><code>EOL</code></td>
+      <td>::=</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code>]</code> <code>+</code> </td>
     </tr>
   </tbody>
 </table>
+    

--- a/spec/ntriples.bnf
+++ b/spec/ntriples.bnf
@@ -1,43 +1,40 @@
-[1]  ntriplesDoc        ::= triple? (EOL triple)* EOL?
-[2]  triple             ::= subject predicate object '.'
-[3]  subject            ::= IRIREF | BLANK_NODE_LABEL
-[4]  predicate          ::= IRIREF 
-[5]  object             ::= IRIREF | BLANK_NODE_LABEL | literal
-[6]  literal            ::= STRING_LITERAL_QUOTE ('^^' IRIREF | LANGTAG )?
+ntriplesDoc       ::= triple? (EOL triple)* EOL?
+triple            ::= subject predicate object '.'
+subject           ::= IRIREF | BLANK_NODE_LABEL | quotedTriple
+predicate         ::= IRIREF
+object            ::= IRIREF | BLANK_NODE_LABEL | literal | quotedTriple
+literal           ::= STRING_LITERAL_QUOTE ('^^' IRIREF | LANGTAG )?
+quotedTriple      ::= '<<' subject predicate object '>>'
 
 @terminals
 
-[144s] LANGTAG          ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )* 
-
-[7]  EOL                ::= [#xD#xA]+
-
-[8] IRIREF ::=  '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
-[9] STRING_LITERAL_QUOTE ::= '"' ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* '"' 
-
-[141s] BLANK_NODE_LABEL ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?
-[10] UCHAR ::= ( "\u" HEX HEX HEX HEX ) 
- | ( "\U" HEX HEX HEX HEX HEX HEX HEX HEX ) 
-[153s] ECHAR ::= "\" [tbnrf"'] 
-[157s] PN_CHARS_BASE    ::= [A-Z] 
-                        | [a-z] 
-                        | [#x00C0-#x00D6] 
-                        | [#x00D8-#x00F6] 
-                        | [#x00F8-#x02FF] 
-                        | [#x0370-#x037D] 
-                        | [#x037F-#x1FFF] 
-                        | [#x200C-#x200D] 
-                        | [#x2070-#x218F] 
-                        | [#x2C00-#x2FEF] 
-                        | [#x3001-#xD7FF] 
-                        | [#xF900-#xFDCF] 
-                        | [#xFDF0-#xFFFD] 
-                        | [#x10000-#xEFFFF] 
-[164s] PN_CHARS_U       ::=  PN_CHARS_BASE 
-                        | '_' 
-[160s] PN_CHARS         ::= PN_CHARS_U 
-                        | "-" 
-                        | [0-9] 
-                        | #x00B7 
-                        | [#x0300-#x036F] 
-                        | [#x203F-#x2040] 
-[162s] HEX              ::= [0-9] | [A-F] | [a-f]
+IRIREF            ::=  '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
+BLANK_NODE_LABEL  ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?
+LANGTAG           ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )*
+STRING_LITERAL_QUOTE ::= '"' ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* '"'
+UCHAR             ::= ( "\u" HEX HEX HEX HEX )
+                    | ( "\U" HEX HEX HEX HEX HEX HEX HEX HEX )
+ECHAR             ::= "\" [tbnrf"']
+PN_CHARS_BASE     ::= [A-Z]
+                    | [a-z]
+                    | [#x00C0-#x00D6]
+                    | [#x00D8-#x00F6]
+                    | [#x00F8-#x02FF]
+                    | [#x0370-#x037D]
+                    | [#x037F-#x1FFF]
+                    | [#x200C-#x200D]
+                    | [#x2070-#x218F]
+                    | [#x2C00-#x2FEF]
+                    | [#x3001-#xD7FF]
+                    | [#xF900-#xFDCF]
+                    | [#xFDF0-#xFFFD]
+                    | [#x10000-#xEFFFF]
+PN_CHARS_U        ::=  PN_CHARS_BASE | '_'
+PN_CHARS          ::= PN_CHARS_U
+                    | "-"
+                    | [0-9]
+                    | #x00B7
+                    | [#x0300-#x036F]
+                    | [#x203F-#x2040]
+HEX               ::= [0-9] | [A-F] | [a-f]
+EOL               ::= [#xD#xA]+


### PR DESCRIPTION
Note, this updates the raw EBNF to remove production numbers, and auto-generate the production numbers in the HTML serialization.

It is dependent on w3c/rdf-concepts#32.

Fixes #9.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/pull/21.html" title="Last updated on Apr 20, 2023, 9:19 PM UTC (55c244d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/21/9975d07...55c244d.html" title="Last updated on Apr 20, 2023, 9:19 PM UTC (55c244d)">Diff</a>