### PR TITLE
Adds BNF and text to extend LANGTAG to support base direction 

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -35,7 +35,7 @@
         { name: "David Beckett", url: "http://www.dajobe.org/", }
       ],
 
-      xref: ["RDF11-CONCEPTS"], // Fixme: change to RDF12-CONCEPTS
+      xref: ["RDF12-CONCEPTS"],
       github: "https://github.com/w3c/rdf-n-triples/",
       group:           "rdf-star",
       doJsonLd:     true,
@@ -120,8 +120,9 @@
       <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a>, and
       <a data-cite="RDF12-CONCEPTS#dfn-object">object</a>
       of an <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF Triple</a>.
-      These may be separated by white space (spaces <code>U+0020</code> or tabs <code>U+0009</code>).
-      This sequence is terminated by a '<code>.</code>'
+      These may be separated by white space
+      (spaces, code point <code class="codepoint">U+0020</code>, and/or tabs, code point <code class="codepoint">U+0009</code>).
+      This sequence is terminated <code>.</code> after the object
       (optionally followed by white space and/or a comment),
       and a new line (optional at the end of a document).</p>
 
@@ -140,7 +141,7 @@
       but Turtle includes other representations of RDF terms and
       <a data-cite="RDF12-TURTLE#predicate-lists">abbreviations of RDF Triples</a>.
       When parsed by a Turtle parser,
-      data in the N-Triples format will produce exactly the same triples as a parser for the N-triples language.
+      data in the N-Triples format will produce exactly the same triples as a parser for the N-Triples language.
     </p>
 
     <p>The <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a> represented by an N-Triples document contains
@@ -161,7 +162,8 @@
       <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a>, and
       <a data-cite="RDF12-CONCEPTS#dfn-object">object</a>
       and optional <a>blank lines</a>.
-      Comments may be given after a '<code>#</code>' that is not part of
+      Comments may be given after a <code>#</code> (number sign, <code class="codepoint">U+0023</code>)
+      that is not part of
       another lexical token and continue to the end of the line.</p>
 
     <section id="simple-triples">
@@ -171,11 +173,12 @@
         (<a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a>,
         <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a>, and
         <a data-cite="RDF12-CONCEPTS#dfn-object">object</a>) terms,
-        and terminated by '<code>.</code>'.
-        White space (spaces <code>U+0020</code> or tabs <code>U+0009</code>) may surround terms,
+        and terminated by <code>.</code>.
+        White space (spaces <code class="codepoint">U+0020</code> or tabs <code class="codepoint">U+0009</code>) may surround terms,
         except where significant as noted in the <a href="#n-triples-grammar">grammar</a>.</p>
 
-      <p>Comments are treated as white space, and may be given after a '<code>#</code>' that is not part of
+      <p>Comments are treated as white space, and may be given after a <code>#</code> (number sign, <code class="codepoint">U+0023</code>)
+        that is not part of
         another lexical token and continue to the end of the line.</p>
 
       <pre id="ex-simple-triple" class="example ntriples" data-transform="updateExample"
@@ -199,8 +202,8 @@
         <code><a href="#grammar-production-subject">subject</a></code>,
         <code><a href="#grammar-production-predicate">predicate</a></code>, and
         <code><a href="#grammar-production-object">object</a></code>
-        preceded by two concatenated <code>&lt;</code> characters, each having the code point <span class="codepoint">U+003C</span>, and
-        followed by two concatenated <code>&gt;</code> characters, each having the code point <span class="codepoint">U+003E</span>.
+        preceded by <code>&lt;&lt;</code> (two concatenated less-than sign characters, each having the code point <code class="codepoint">U+003C</code>), and
+        followed by <code>&gt;&gt;</code> (two concatenated greater-than sign characters, each having the code point <code class="codepoint">U+003E</code>).
         Note that <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</a>
         may be nested.
        </p>
@@ -219,8 +222,8 @@
 
       <p>
         <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a> may be written only as <a data-cite="RFC3986#section-5">resolved</a> IRIs.
-        IRIs are preceded by <code>&lt;</code> (code point <span class="codepoint">U+003C</span>) and
-        followed by <code>&gt;</code> (code point <span class="codepoint">U+003E</span>),
+        IRIs are preceded by <code>&lt;</code> (code point <code class="codepoint">U+003C</code>) and
+        followed by <code>&gt;</code> (code point <code class="codepoint">U+003E</code>),
         and may contain numeric escape sequences (described below).
         For example <code>&lt;http://example.org/#green-goblin&gt;</code>.
       </p>
@@ -245,12 +248,12 @@
         and a final delimiter.</p>
 
       <p>Literals may not contain the characters <code>&quot;</code>,
-        <code title="LINE FEED"><sub>LF</sub></code> (<code class="codepoint">U+000A</code>), or
-        <code title="CARRIAGE RETURN"><sub>CR</sub></code> (<code class="codepoint">U+000D</code>)
+        <code>LF</code> (line feed, code point <code class="codepoint">U+000A</code>), or
+        <code>CR</code> (carriage return, code point <code class="codepoint">U+000D</code>)
         except in their escaped forms.
-        In addition '<code>\</code>' (<code class="codepoint">U+005C</code>)
+        In addition <code>\</code> (backslash, code point <code class="codepoint">U+005C</code>)
         may not appear in any quoted literal except as part of an escape sequence
-        and a <code>"</code> (<code class="codepoint">U+0022</code>) character
+        and a <code>&quot;</code> (quotation mark, <code class="codepoint">U+0022</code>) character
         can only be included in a quote literal using an escape sequence.
         </p>
 
@@ -260,17 +263,17 @@
         terminal matches the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
         and optionally the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>.
         The <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
-        is preceded by an at sign ('<code>@</code>', <code class="codepoint">U+0040</code>),
+        is preceded by an <code>@</code> (at sign, <code class="codepoint">U+0040</code>),
         and, if present, the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
-        is separated from the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> by '<code>--</code>'.
+        is separated from the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
+        by <code>--</code> (two concatenated hyphen characters, each having the code point <code class="codepoint">U+002D</code>).
         If there is no language tag, there may be a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>,
-        preceded by two concatenated <code>^</code> characters,
-        each having the code point <code class="codepoint">U+005E</code>.
+        preceded by <code>^^</code>
+        (two concatenated circumflex accent characters, each having the code point <code class="codepoint">U+005E</code>).
         If there is no datatype IRI and no language tag, then
         it is a <a data-cite="RDF12-CONCEPTS#dfn-simple-literal">simple literal</a>
         and the datatype is <code>http://www.w3.org/2001/XMLSchema#string</code>.
       </p>
-
 
       <pre id="ex-literals" class="example ntriples" data-transform="updateExample"
            title="Literals in N-Triples">
@@ -290,17 +293,33 @@
     <section id="BNodes">
       <h3>RDF Blank Nodes</h3>
       <p>
-        <a data-cite="RDF12-CONCEPTS#dfn-blank-node">RDF blank nodes</a> in N-Triples are expressed as <code>_:</code> followed by a blank node label which is a series of name characters.
-        The characters in the label are built upon <a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a>, liberalized as follows:
+        <a data-cite="RDF12-CONCEPTS#dfn-blank-node">RDF blank nodes</a> in N-Triples are expressed
+        as <code>_:</code> followed by a <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a> which is a series of characters.
+        The characters in the identifier are built upon
+        <a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a>,
+        liberalized as follows:
       </p>
       <ul>
-        <li>The characters <code>_</code> and <code>[0-9]</code> may appear anywhere in a blank node label.</li>
-        <li>The character <code>.</code> may appear anywhere except the first or last character.</li>
-        <li>The characters <code>-</code>, <code>U+00B7</code>, <code>U+0300</code> to <code>U+036F</code> and <code>U+203F</code> to <code>U+2040</code> are permitted anywhere except the first character.</li>
+        <li>The character <code>_</code> (underscore, <code class="codepoint">U+005F</code>) and
+          the digit characters <code>0</code>–<code>9</code> (zero through nine, 
+          <code class="codepoint">U+0030</code> 
+          through <code class="codepoint">U+0039</code>, inclusive)
+          may appear anywhere in a
+          <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a>.</li>
+        <li>The character <code>.</code> (full stop, <code class="codepoint">U+002E</code>) may appear anywhere except the first or last character.</li>
+        <li>The characters
+          <code>-</code> (hyphen, <code class="codepoint">U+2010</code>),
+          <code>.</code> (full stop, <code class="codepoint">U+002E</code >),
+          &#x203F;&nbsp; (undertie, <code class="codepoint">U+203F</code>),
+          &#x2040;&nbsp; (character tie, <code class="codepoint">U+2040</code>),
+          and
+          the combining diacritical marks (<code class="codepoint">U+0300</code>
+                                        to <code class="codepoint">U+036F</code>)
+          are permitted anywhere except the first character.</li>
       </ul>
       <p>
-        A fresh RDF blank node is allocated for each unique blank node label in a document.
-        Repeated use of the same blank node label identifies the same RDF blank node.
+        A fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a> is allocated for each unique <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a> in a document.
+        Repeated use of the same <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a> identifies the same blank node.
       </p>
       <pre id="ex-bnodes" class="example ntriples" data-transform="updateExample"
            title="Blank nodes in N-Triples">
@@ -334,7 +353,7 @@
         <code>subject</code>,
         <code>predicate</code>,  and
         <code>object</code>,
-        any of which MUST be a single space (<code>U+0020</code>).</li>
+        any of which MUST be a single space (<code class="codepoint">U+0020</code>).</li>
       <li><a data-cite="RDF12-CONCEPTS#dfn-literal">Literals</a> with the
         datatype <code>http://www.w3.org/2001/XMLSchema#string</code>
         MUST NOT use the <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> part of the <a href="#grammar-production-literal">literal</a>,
@@ -413,9 +432,8 @@
     <section id="sec-grammar-ws">
       <h3>White Space</h3>
 
-      <p>White space (tab U+0009 or space U+0020) is allowed outside of terminals.
-        Rule names below in capitals indicate where white space is significant.
-</p>
+      <p>White space (spaces <code class="codepoint">U+0020</code> or tabs <code class="codepoint">U+0009</code>) is allowed outside of terminals.
+        Rule names below in capitals indicate where white space is significant.</p>
 
       <p>White space is significant in the production <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.</p>
 
@@ -423,24 +441,23 @@
         may appear wherever a <code><a href="#grammar-production-triple">triple</a></code> production is allowed,
         and are treated as white space.</p>
 
-      <p class="note">N-Triples allows only horizontal white space  (tab U+0009 or space U+0020)
+      <p class="note">N-Triples allows only horizontal white space (spaces <code class="codepoint">U+0020</code> or tabs <code class="codepoint">U+0009</code>)
         as compared to Turtle [[RDF12-TURTLE]] which also treats
-        <code title="LINE FEED"><sub>LF</sub></code> (<code class="codepoint">U+000A</code>)
-        and <code title="CARRIAGE RETURN"><sub>CR</sub></code> (<code class="codepoint">U+000D</code>)
+        <code>LF</code> (line feed, code point <code class="codepoint">U+000A</code>)
+        and <code>CR</code> (carriage return, code point <code class="codepoint">U+000D</code>)
         as white space.</p>
     </section>
 
     <section id="sec-grammar-comments">
       <h3>Comments</h3>
 
-      <p>Comments in N-Triples start at '<code>#</code>'
+      <p>Comments in N-Triples start at <code>#</code> (number sign, <code class="codepoint">U+0023</code>)
         outside an <a href="#grammar-production-IRIREF">IRIREF</a> or <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
         and continue to the end of line
         (marked by characters
-        <code title="CARRIAGE RETURN"><sub>CR</sub></code> (<code class="codepoint">U+000D</code> or
-        <code title="LINE FEED"><sub>LF</sub></code> (<code class="codepoint">U+000A</code>))
-        or end of file if there is no end of line after the comment
-        marker.
+        <code>CR</code> (carriage return, code point <code class="codepoint">U+000D</code>) or
+        <code>LF</code> (line feed, code point <code class="codepoint">U+000A</code>))
+        or end of file if there is no end of line after the comment marker.
         Comments are treated as white space.</p>
     </section>
 
@@ -483,9 +500,9 @@
               <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>
             </td>
             <td>
-              The string after '<code>_:</code>',
+              The string matching the second argument, <a href="#grammar-production-PN_LOCAL" class="type bNode">PN_LOCAL</a>,
               is a key in <a href="#bnodeLabels">bnodeLabels</a>.
-              If there is no corresponding blank node in the map,
+              If there is no corresponding <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a> in the map,
               one is allocated.
             </td>
           </tr>
@@ -497,9 +514,9 @@
               <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a>
             </td>
             <td>
-              The characters between &quot;&lt;&quot; and &quot;&gt;&quot; are taken,
-              with escape sequences unescaped,
-              to form the unicode string of the IRI.
+              The characters between <code>&lt;</code> and <code>&gt;</code> are taken,
+              with the <a href="#numeric">numeric escape sequences</a> unescaped,
+              to form the IRI.
             </td>
           </tr>
           <tr id="handle-LANG_DIR">
@@ -510,12 +527,11 @@
               <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
             </td>
             <td>
-              The characters following the at sign (<code>@</code>) form the Unicode
-              string of the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
+              The characters following the <code>@</code> (at sign, <code class="codepoint">U+0040</code>)
+              form the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               and optionally the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
-              if the matched characters
-              include two concatenated <code>-</code> characters,
-              each having the code point <code class="codepoint">U+002D</code>.
+              if the matched characters include
+              <code>--</code> (two concatenated hyphen characters, each having the code point <code class="codepoint">U+002D</code>).
             </td>
           </tr>
           <tr id="handle-STRING_LITERAL_QUOTE">
@@ -526,9 +542,9 @@
               <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a>
             </td>
             <td>
-              The characters between the outermost quotation marks (<code>&quot;</code>) are taken,
-              with escape sequences unescaped,
-              to form the unicode string of a lexical form.
+              The characters between the outermost <code>"</code>s are taken,
+              with <a href="#numeric">numeric</a> and <a href="#string">string</a> escape sequences unescaped,
+              to form the <a data-cite="RDF12-CONCEPTS#dfn-rdf-string">RDF string</a> of a lexical form.
             </td>
           </tr>
           <tr id="handle-literal">
@@ -542,27 +558,17 @@
               <code>STRING_LITERAL_QUOTE</code>,
               and either a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               with optional <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
-              from <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code>
+              from <code><a href="#handle-LANG_DIR" class="type langDir">LANG_DIR</a></code>
               or a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> of <code>iri</code>,
               depending on which rule matched the input.
               If the <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code> rule matches,
-              it is split into <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
-              and <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
-              on '<code>--</code>' (two concatenated <span class="unicode">U+002D</span> code points).
+              the language tag and base direction are taken from <a href=#handle-LANG_DIR class="type langDir">LANG_DIR</a>.
               If there is no <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
-              the datatype is <code>rdf:langString</code>
-              and the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code>.
+              the datatype is <code>rdf:langString</code>.
               If there is a <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
-              the datatype is <code>rdf:dirLangString</code>,
-              the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is
-              taken from the portion of the matched
-              <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code>
-              preceding '<code>--</code>' (two concatenated <span class="unicode">U+002D</span> code points)
-              and the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
-              is taken from the portion of the matched <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code>
-              following '<code>--</code>' (two concatenated <span class="unicode">U+002D</span> code points).
-              If neither a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
-              nor a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> is present,
+              the datatype is <code>rdf:dirLangString</code>.
+              If neither <code><a href="#handle-LANG_DIR" class="type langDir">LANG_DIR</a></code>
+              nor <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> match,
               the literal has a datatype of <code>xsd:string</code>.
             </td>
           </tr>

--- a/spec/index.html
+++ b/spec/index.html
@@ -85,7 +85,9 @@
       <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
       <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of another
       <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a>,
-      making it possible to make statements about other statements.</p>
+      making it possible to make statements about other statements.
+      RDF 1.2 N-Triples also adds support for
+      <a data-cite="RDF12-CONCEPTS#dfn-dir-lang-string">directional language-tagged strings</a>.</p>
   </section>
 
   <section id='sotd'>
@@ -231,7 +233,11 @@
         are used to identify values such as strings, numbers, dates.</p>
 
       <p>Literals (Grammar production <a href="#grammar-production-literal">Literal</a>)
-        have a lexical form followed by a language tag, a datatype IRI, or neither.</p>
+        have a lexical form followed by a
+        <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
+        (possibly including <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>),
+        a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>,
+        or neither.</p>
 
       <p>The representation of the lexical form consists of an
         initial delimiter <code>&quot;</code> (<span class="codepoint">U+0022</span>),
@@ -252,6 +258,9 @@
         is the characters between the delimiters, after processing any escape sequences.
         If present, the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
         is preceded by a '<code>@</code>' (<span class="codepoint">U+0040</span>).
+        If present, the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
+        is included in the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
+        separated by '<code>--</code>'.
         If there is no language tag, there may be a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>,
         preceded by two concatenated <code>^</code> characters,
         each having the code point <span class="codepoint">U+005E</span>.
@@ -267,8 +276,9 @@
         <http://example.org/show/218> <http://www.w3.org/2000/01/rdf-schema#label> "That Seventies Show"^^<http://www.w3.org/2001/XMLSchema#string> . # literal with XML Schema string datatype
         <http://example.org/show/218> <http://www.w3.org/2000/01/rdf-schema#label> "That Seventies Show" . # same as above
         <http://example.org/show/218> <http://example.org/show/localName> "That Seventies Show"@en . # literal with a language tag
+        <http://example.org/show/218> <http://example.org/show/localName> "That Seventies Show"@en-ltr . # literal with a language tag and base direction
         <http://example.org/show/218> <http://example.org/show/localName> "Cette Série des Années Septante"@fr-be .  # literal outside of ASCII range with a region subtag
-        <http://example.org/#spiderman> <http://example.org/text> "This is a multi-linenliteral with many quotes (""""")nand two apostrophes ('')." .
+        <http://example.org/#spiderman> <http://example.org/text> "This is a multi-linenliteral with many quotes (""""") and two apostrophes ('')." .
         <http://en.wikipedia.org/wiki/Helium> <http://example.org/elements/atomicNumber> "2"^^<http://www.w3.org/2001/XMLSchema#integer> . # xsd:integer
         <http://en.wikipedia.org/wiki/Helium> <http://example.org/elements/specificGravity> "1.663E-4"^^<http://www.w3.org/2001/XMLSchema#double> .     # xsd:double
         -->
@@ -325,7 +335,7 @@
         any of which MUST be a single space (<code>U+0020</code>).</li>
       <li><a data-cite="RDF12-CONCEPTS#dfn-literal">Literals</a> with the
         datatype <code>http://www.w3.org/2001/XMLSchema#string</code>
-        MUST NOT use the datatype IRI part of the <a href="#grammar-production-literal">literal</a>,
+        MUST NOT use the <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> part of the <a href="#grammar-production-literal">literal</a>,
         and are represented using only <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.
       </li>
       <li><code><a href="#grammar-production-HEX">HEX</a></code> MUST use only uppercase letters (<code>[A-F]</code>).</li>
@@ -498,7 +508,9 @@
               <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
             </td>
             <td>
-              The characters following the <code>@</code> form the unicode string of the language tag.
+              The characters following the <code>@</code> form the unicode string of the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
+              and optionally the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
+              if the matched characters include '<code>--</code>'.
             </td>
           </tr>
           <tr id="handle-STRING_LITERAL_QUOTE">
@@ -523,13 +535,24 @@
             <td>
               The literal has a lexical form of the first rule argument,
               <code>STRING_LITERAL_QUOTE</code>,
-              and either a language tag of <code>LANGTAG</code>
-              or a datatype IRI of <code>iri</code>,
+              and either a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
+              with optional <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
+              from <code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code>
+              or a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> of <code>iri</code>,
               depending on which rule matched the input.
-              If the <code>LANGTAG</code> rule matched,
+              If the <code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code> rule matched,
+              it is split into <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
+              and <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
+              on '<code>--</code>'.
+              If there is no <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
               the datatype is <code>rdf:langString</code>
-              and the language tag is <code>LANGTAG</code>.
-              If neither a language tag nor a datatype IRI is provided,
+              and the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is <code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code>.
+              If there is a base direction, the datatype is <code>rdf:dirLangString</code>,
+              the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is
+              taken from the portion of the matched <code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code> proceding '<code>--</code>'
+              and the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
+              is taken from the portion of the matched <code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code> following '<code>--</code>'.
+              If neither a language tag nor a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> is provided,
               the literal has a datatype of <code>xsd:string</code>.
             </td>
           </tr>
@@ -743,8 +766,10 @@
     <li>Separated <a href="#security"></a> from <a href="#sec-mediaReg-n-triples"></a>
       and updated language.</li>
     <li>Changes <a href="#canonical-ntriples"></a> to clarify
-      use of datatype IRIs and expand the use of escapes
+      use of <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRIs</a> and expand the use of escapes
       in literals.</li>
+    <li>Extends <a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a> to include
+      an optional <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>.</li>
 </ul>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -236,7 +236,7 @@
         have a lexical form followed by either a
         <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
         (possibly including <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>),
-        or a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>,
+        a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>,
         or neither.</p>
 
       <p>The representation of the lexical form consists of an
@@ -511,7 +511,8 @@
               <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
             </td>
             <td>
-              The characters following the <code>@</code> form the Unicode string of the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
+              The characters following the at sign (<code>@</code>) form the Unicode
+              string of the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               and optionally the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
               if the matched characters include '<code>--</code>'.
             </td>

--- a/spec/index.html
+++ b/spec/index.html
@@ -233,10 +233,10 @@
         are used to identify values such as strings, numbers, dates.</p>
 
       <p>Literals (Grammar production <a href="#grammar-production-literal">Literal</a>)
-        have a lexical form followed by a
+        have a lexical form followed by either a
         <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
         (possibly including <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>),
-        a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>,
+        or a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>,
         or neither.</p>
 
       <p>The representation of the lexical form consists of an
@@ -260,7 +260,7 @@
         terminal matches the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
         and optionally the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>.
         The <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
-        is preceded by a '<code>@</code>' (<span class="codepoint">U+0040</span>),
+        is preceded by an at sign ('<code>@</code>', <span class="codepoint">U+0040</span>),
         and, if present, the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
         is separated from the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> by '<code>--</code>'.
         If there is no language tag, there may be a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>,
@@ -281,7 +281,7 @@
         <http://example.org/show/218> <http://example.org/show/localName> "That Seventies Show"@en . # literal with a language tag
         <http://example.org/show/218> <http://example.org/show/localName> "That Seventies Show"@en-ltr . # literal with a language tag and base direction
         <http://example.org/show/218> <http://example.org/show/localName> "Cette Série des Années Septante"@fr-be .  # literal outside of ASCII range with a region subtag
-        <http://example.org/#spiderman> <http://example.org/text> "This is a multi-linenliteral with many quotes (""""") and two apostrophes ('')." .
+        <http://example.org/#spiderman> <http://example.org/text> "This is a multi-line literal with many quotation marks (""""") and two apostrophes ('')." .
         <http://en.wikipedia.org/wiki/Helium> <http://example.org/elements/atomicNumber> "2"^^<http://www.w3.org/2001/XMLSchema#integer> . # xsd:integer
         <http://en.wikipedia.org/wiki/Helium> <http://example.org/elements/specificGravity> "1.663E-4"^^<http://www.w3.org/2001/XMLSchema#double> .     # xsd:double
         -->
@@ -511,7 +511,7 @@
               <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
             </td>
             <td>
-              The characters following the <code>@</code> form the unicode string of the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
+              The characters following the <code>@</code> form the Unicode string of the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               and optionally the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
               if the matched characters include '<code>--</code>'.
             </td>
@@ -543,7 +543,7 @@
               from <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code>
               or a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> of <code>iri</code>,
               depending on which rule matched the input.
-              If the <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code> rule matched,
+              If the <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code> rule matches,
               it is split into <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               and <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
               on '<code>--</code>'.
@@ -553,11 +553,11 @@
               If there is a <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
               the datatype is <code>rdf:dirLangString</code>,
               the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is
-              taken from the portion of the matched <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code> proceding '<code>--</code>'
+              taken from the portion of the matched <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code> preceding '<code>--</code>'
               and the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
               is taken from the portion of the matched <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code> following '<code>--</code>'.
               If neither a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
-              nor a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> is provided,
+              nor a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> is present,
               the literal has a datatype of <code>xsd:string</code>.
             </td>
           </tr>

--- a/spec/index.html
+++ b/spec/index.html
@@ -256,7 +256,7 @@
 
       <p>The corresponding <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">RDF lexical form</a>
         is the characters between the delimiters, after processing any escape sequences.
-        If present, the <a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a>
+        If present, the <a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a>
         terminal matches the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
         and optionally the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>.
         The <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
@@ -264,7 +264,6 @@
         and, if present, the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
         is separated from the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> by '<code>--</code>'.
         If there is no language tag, there may be a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>,
-        there may be a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>,
         preceded by two concatenated <code>^</code> characters,
         each having the code point <span class="codepoint">U+005E</span>.
         If there is no datatype IRI and no language tag
@@ -505,7 +504,7 @@
           </tr>
           <tr id="handle-LANGDIR">
             <td style="text-align:left;">
-              <a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a>
+              <a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a>
             </td>
             <td>
               <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
@@ -541,22 +540,22 @@
               <code>STRING_LITERAL_QUOTE</code>,
               and either a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               with optional <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
-              from <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code>
+              from <code><a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a></code>
               or a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> of <code>iri</code>,
               depending on which rule matched the input.
-              If the <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code> rule matches,
+              If the <code><a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a></code> rule matches,
               it is split into <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               and <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
               on '<code>--</code>'.
               If there is no <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
               the datatype is <code>rdf:langString</code>
-              and the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code>.
+              and the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is <code><a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a></code>.
               If there is a <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
               the datatype is <code>rdf:dirLangString</code>,
               the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is
-              taken from the portion of the matched <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code> preceding '<code>--</code>'
+              taken from the portion of the matched <code><a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a></code> preceding '<code>--</code>'
               and the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
-              is taken from the portion of the matched <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code> following '<code>--</code>'.
+              is taken from the portion of the matched <code><a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a></code> following '<code>--</code>'.
               If neither a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               nor a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> is present,
               the literal has a datatype of <code>xsd:string</code>.
@@ -775,7 +774,7 @@
       use of <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRIs</a> and expand the use of escapes
       in literals.</li>
     <li>Changes the `LANGTAG` terminal production to
-      <a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a> to include
+      <a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a> to include
       an optional <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>.</li>
 </ul>
 </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -500,7 +500,7 @@
               <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>
             </td>
             <td>
-              The string matching the second argument, <a href="#grammar-production-PN_LOCAL" class="type bNode">PN_LOCAL</a>,
+              The string after '<code>_:</code>',
               is a key in <a href="#bnodeLabels">bnodeLabels</a>.
               If there is no corresponding <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a> in the map,
               one is allocated.
@@ -515,7 +515,7 @@
             </td>
             <td>
               The characters between <code>&lt;</code> and <code>&gt;</code> are taken,
-              with the <a href="#numeric">numeric escape sequences</a> unescaped,
+              with escape sequences unescaped,
               to form the IRI.
             </td>
           </tr>
@@ -543,7 +543,7 @@
             </td>
             <td>
               The characters between the outermost <code>"</code>s are taken,
-              with <a href="#numeric">numeric</a> and <a href="#string">string</a> escape sequences unescaped,
+              with escape sequences unescaped,
               to form the <a data-cite="RDF12-CONCEPTS#dfn-rdf-string">RDF string</a> of a lexical form.
             </td>
           </tr>

--- a/spec/index.html
+++ b/spec/index.html
@@ -256,12 +256,15 @@
 
       <p>The corresponding <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">RDF lexical form</a>
         is the characters between the delimiters, after processing any escape sequences.
-        If present, the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
-        is preceded by a '<code>@</code>' (<span class="codepoint">U+0040</span>).
-        If present, the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
-        is included in the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
-        separated by '<code>--</code>'.
+        If present, the <a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a>
+        terminal matches the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
+        and optionally the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>.
+        The <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
+        is preceded by a '<code>@</code>' (<span class="codepoint">U+0040</span>),
+        and, if present, the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
+        is separated from the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> by '<code>--</code>'.
         If there is no language tag, there may be a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>,
+        there may be a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>,
         preceded by two concatenated <code>^</code> characters,
         each having the code point <span class="codepoint">U+005E</span>.
         If there is no datatype IRI and no language tag
@@ -500,9 +503,9 @@
               to form the unicode string of the IRI.
             </td>
           </tr>
-          <tr id="handle-LANGTAG">
+          <tr id="handle-LANGDIR">
             <td style="text-align:left;">
-              <a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a>
+              <a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a>
             </td>
             <td>
               <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
@@ -537,22 +540,24 @@
               <code>STRING_LITERAL_QUOTE</code>,
               and either a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               with optional <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
-              from <code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code>
+              from <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code>
               or a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> of <code>iri</code>,
               depending on which rule matched the input.
-              If the <code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code> rule matched,
+              If the <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code> rule matched,
               it is split into <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               and <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
               on '<code>--</code>'.
               If there is no <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
               the datatype is <code>rdf:langString</code>
-              and the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is <code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code>.
-              If there is a base direction, the datatype is <code>rdf:dirLangString</code>,
+              and the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code>.
+              If there is a <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
+              the datatype is <code>rdf:dirLangString</code>,
               the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is
-              taken from the portion of the matched <code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code> proceding '<code>--</code>'
+              taken from the portion of the matched <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code> proceding '<code>--</code>'
               and the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
-              is taken from the portion of the matched <code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code> following '<code>--</code>'.
-              If neither a language tag nor a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> is provided,
+              is taken from the portion of the matched <code><a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a></code> following '<code>--</code>'.
+              If neither a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
+              nor a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> is provided,
               the literal has a datatype of <code>xsd:string</code>.
             </td>
           </tr>
@@ -768,7 +773,8 @@
     <li>Changes <a href="#canonical-ntriples"></a> to clarify
       use of <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRIs</a> and expand the use of escapes
       in literals.</li>
-    <li>Extends <a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a> to include
+    <li>Changes the `LANGTAG` terminal production to
+      <a href="#grammar-production-LANGDIR" class="type langTag">LANGDIR</a> to include
       an optional <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>.</li>
 </ul>
 </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -266,7 +266,7 @@
         If there is no language tag, there may be a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>,
         preceded by two concatenated <code>^</code> characters,
         each having the code point <span class="codepoint">U+005E</span>.
-        If there is no datatype IRI and no language tag
+        If there is no datatype IRI and no language tag, then
         it is a <a data-cite="RDF12-CONCEPTS#dfn-simple-literal">simple literal</a>
         and the datatype is <code>http://www.w3.org/2001/XMLSchema#string</code>.
       </p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -256,7 +256,7 @@
 
       <p>The corresponding <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">RDF lexical form</a>
         is the characters between the delimiters, after processing any escape sequences.
-        If present, the <a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a>
+        If present, the <a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a>
         terminal matches the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
         and optionally the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>.
         The <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
@@ -502,9 +502,9 @@
               to form the unicode string of the IRI.
             </td>
           </tr>
-          <tr id="handle-LANGDIR">
+          <tr id="handle-LANG_DIR">
             <td style="text-align:left;">
-              <a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a>
+              <a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a>
             </td>
             <td>
               <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
@@ -540,22 +540,22 @@
               <code>STRING_LITERAL_QUOTE</code>,
               and either a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               with optional <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
-              from <code><a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a></code>
+              from <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code>
               or a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> of <code>iri</code>,
               depending on which rule matched the input.
-              If the <code><a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a></code> rule matches,
+              If the <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code> rule matches,
               it is split into <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               and <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
               on '<code>--</code>'.
               If there is no <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
               the datatype is <code>rdf:langString</code>
-              and the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is <code><a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a></code>.
+              and the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code>.
               If there is a <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
               the datatype is <code>rdf:dirLangString</code>,
               the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is
-              taken from the portion of the matched <code><a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a></code> preceding '<code>--</code>'
+              taken from the portion of the matched <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code> preceding '<code>--</code>'
               and the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
-              is taken from the portion of the matched <code><a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a></code> following '<code>--</code>'.
+              is taken from the portion of the matched <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code> following '<code>--</code>'.
               If neither a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               nor a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> is present,
               the literal has a datatype of <code>xsd:string</code>.
@@ -774,7 +774,7 @@
       use of <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRIs</a> and expand the use of escapes
       in literals.</li>
     <li>Changes the `LANGTAG` terminal production to
-      <a href="#grammar-production-LANGDIR" class="type langDir">LANGDIR</a> to include
+      <a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a> to include
       an optional <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>.</li>
 </ul>
 </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -240,17 +240,17 @@
         or neither.</p>
 
       <p>The representation of the lexical form consists of an
-        initial delimiter <code>&quot;</code> (<span class="codepoint">U+0022</span>),
+        initial delimiter <code>&quot;</code> (<code class="codepoint">U+0022</code>),
         a sequence of permitted characters or numeric escape sequence or string escape sequence,
         and a final delimiter.</p>
 
       <p>Literals may not contain the characters <code>&quot;</code>,
-        <code title="LINE FEED"><sub>LF</sub></code> (<span class="codepoint">U+000A</span>), or
-        <code title="CARRIAGE RETURN"><sub>CR</sub></code> (<span class="codepoint">U+000D</span>)
+        <code title="LINE FEED"><sub>LF</sub></code> (<code class="codepoint">U+000A</code>), or
+        <code title="CARRIAGE RETURN"><sub>CR</sub></code> (<code class="codepoint">U+000D</code>)
         except in their escaped forms.
-        In addition '<code>\</code>' (<span class="codepoint">U+005C</span>)
+        In addition '<code>\</code>' (<code class="codepoint">U+005C</code>)
         may not appear in any quoted literal except as part of an escape sequence
-        and a <code>"</code> (<span class="codepoint">U+0022</span>) character
+        and a <code>"</code> (<code class="codepoint">U+0022</code>) character
         can only be included in a quote literal using an escape sequence.
         </p>
 
@@ -260,12 +260,12 @@
         terminal matches the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
         and optionally the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>.
         The <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
-        is preceded by an at sign ('<code>@</code>', <span class="codepoint">U+0040</span>),
+        is preceded by an at sign ('<code>@</code>', <code class="codepoint">U+0040</code>),
         and, if present, the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
         is separated from the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> by '<code>--</code>'.
         If there is no language tag, there may be a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>,
         preceded by two concatenated <code>^</code> characters,
-        each having the code point <span class="codepoint">U+005E</span>.
+        each having the code point <code class="codepoint">U+005E</code>.
         If there is no datatype IRI and no language tag, then
         it is a <a data-cite="RDF12-CONCEPTS#dfn-simple-literal">simple literal</a>
         and the datatype is <code>http://www.w3.org/2001/XMLSchema#string</code>.
@@ -425,8 +425,8 @@
 
       <p class="note">N-Triples allows only horizontal white space  (tab U+0009 or space U+0020)
         as compared to Turtle [[RDF12-TURTLE]] which also treats
-        <code title="LINE FEED"><sub>LF</sub></code> (<span class="codepoint">U+000A</span>)
-        and <code title="CARRIAGE RETURN"><sub>CR</sub></code> (<span class="codepoint">U+000D</span>)
+        <code title="LINE FEED"><sub>LF</sub></code> (<code class="codepoint">U+000A</code>)
+        and <code title="CARRIAGE RETURN"><sub>CR</sub></code> (<code class="codepoint">U+000D</code>)
         as white space.</p>
     </section>
 
@@ -437,8 +437,8 @@
         outside an <a href="#grammar-production-IRIREF">IRIREF</a> or <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
         and continue to the end of line
         (marked by characters
-        <code title="CARRIAGE RETURN"><sub>CR</sub></code> (<span class="codepoint">U+000D</span> or
-        <code title="LINE FEED"><sub>LF</sub></code> (<span class="codepoint">U+000A</span>))
+        <code title="CARRIAGE RETURN"><sub>CR</sub></code> (<code class="codepoint">U+000D</code> or
+        <code title="LINE FEED"><sub>LF</sub></code> (<code class="codepoint">U+000A</code>))
         or end of file if there is no end of line after the comment
         marker.
         Comments are treated as white space.</p>
@@ -513,7 +513,9 @@
               The characters following the at sign (<code>@</code>) form the Unicode
               string of the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               and optionally the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
-              if the matched characters include '<code>--</code>'.
+              if the matched characters
+              include two concatenated <code>-</code> characters,
+              each having the code point <code class="codepoint">U+002D</code>.
             </td>
           </tr>
           <tr id="handle-STRING_LITERAL_QUOTE">
@@ -546,16 +548,19 @@
               If the <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code> rule matches,
               it is split into <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               and <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
-              on '<code>--</code>'.
+              on '<code>--</code>' (two concatenated <span class="unicode">U+002D</span> code points).
               If there is no <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
               the datatype is <code>rdf:langString</code>
               and the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code>.
               If there is a <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>,
               the datatype is <code>rdf:dirLangString</code>,
               the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> is
-              taken from the portion of the matched <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code> preceding '<code>--</code>'
+              taken from the portion of the matched
+              <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code>
+              preceding '<code>--</code>' (two concatenated <span class="unicode">U+002D</span> code points)
               and the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>
-              is taken from the portion of the matched <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code> following '<code>--</code>'.
+              is taken from the portion of the matched <code><a href="#grammar-production-LANG_DIR" class="type langDir">LANG_DIR</a></code>
+              following '<code>--</code>' (two concatenated <span class="unicode">U+002D</span> code points).
               If neither a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               nor a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a> is present,
               the literal has a datatype of <code>xsd:string</code>.

--- a/spec/ntriples-bnf.html
+++ b/spec/ntriples-bnf.html
@@ -11,7 +11,7 @@
       <td>[2]</td>
       <td><code>triple</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> "<code class="grammar-literal">.</code>"</td>
+      <td><a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> '<code class="grammar-literal">.</code>'</td>
     </tr>
     <tr id="grammar-production-subject">
       <td>[3]</td>
@@ -35,13 +35,13 @@
       <td>[6]</td>
       <td><code>literal</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a> <code class="grammar-paren">(</code><code class="grammar-paren">(</code>"<code class="grammar-literal">^^</code>" <a href="#grammar-production-IRIREF">IRIREF</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <a href="#grammar-production-LANG_DIR">LANG_DIR</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
+      <td><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a> <code class="grammar-paren">(</code><code class="grammar-paren">(</code>'<code class="grammar-literal">^^</code>' <a href="#grammar-production-IRIREF">IRIREF</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <a href="#grammar-production-LANG_DIR">LANG_DIR</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-quotedTriple">
       <td>[7]</td>
       <td><code>quotedTriple</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">&lt;&lt;</code>" <a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> "<code class="grammar-literal">&gt;&gt;</code>"</td>
+      <td>'<code class="grammar-literal">&lt;&lt;</code>' <a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> '<code class="grammar-literal">&gt;&gt;</code>'</td>
     </tr>
     <tr id="grammar-declaration-terminals">
       <td colspan="4">
@@ -52,19 +52,19 @@
       <td>[9]</td>
       <td><code>IRIREF</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">&lt;</code>" <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&lt;&gt;&quot;{}|^`\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> "<code class="grammar-literal">&gt;</code>"</td>
+      <td>'<code class="grammar-literal">&lt;</code>' <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&lt;&gt;&quot;{}|^`\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> '<code class="grammar-literal">&gt;</code>'</td>
     </tr>
     <tr id="grammar-production-BLANK_NODE_LABEL">
       <td>[10]</td>
       <td><code>BLANK_NODE_LABEL</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">_:</code>" <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">.</code>"<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
+      <td>'<code class="grammar-literal">_:</code>' <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>'<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-LANG_DIR">
       <td>[11]</td>
       <td><code>LANG_DIR</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">@</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">-</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">--</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
+      <td>'<code class="grammar-literal">@</code>' <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">-</code>' <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">--</code>' <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_QUOTE">
       <td>[12]</td>
@@ -76,13 +76,13 @@
       <td>[13]</td>
       <td><code>UCHAR</code></td>
       <td>::=</td>
-      <td><code class="grammar-paren">(</code>"<code class="grammar-literal">\u</code>" <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">\U</code>" <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code></td>
+      <td><code class="grammar-paren">(</code>'<code class="grammar-literal">\u</code>' <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">\U</code>' <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-ECHAR">
       <td>[14]</td>
       <td><code>ECHAR</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">\</code>" <code class="grammar-brac">[</code><code class="grammar-literal">tbnrf&quot;&apos;</code><code class="grammar-brac">]</code></td>
+      <td>'<code class="grammar-literal">\</code>' <code class="grammar-brac">[</code><code class="grammar-literal">tbnrf&quot;&apos;</code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_CHARS_BASE">
       <td>[15]</td>
@@ -159,13 +159,13 @@
       <td>[16]</td>
       <td><code>PN_CHARS_U</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">_</code>"</td>
+      <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">_</code>'</td>
     </tr>
     <tr id="grammar-production-PN_CHARS">
       <td>[17]</td>
       <td><code>PN_CHARS</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">-</code>" <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="unicode U+00B7">#xB7</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+0300">#x0300</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+036F">#x036F</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+203F">#x203F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+2040">#x2040</abbr></code><code class="grammar-brac">]</code></td>
+      <td><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">-</code>' <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="unicode U+00B7">#xB7</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+0300">#x0300</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+036F">#x036F</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+203F">#x203F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+2040">#x2040</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-HEX">
       <td>[18]</td>

--- a/spec/ntriples-bnf.html
+++ b/spec/ntriples-bnf.html
@@ -35,7 +35,7 @@
       <td>[6]</td>
       <td><code>literal</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a> <code class="grammar-paren">(</code><code class="grammar-paren">(</code>"<code class="grammar-literal">^^</code>" <a href="#grammar-production-IRIREF">IRIREF</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <a href="#grammar-production-LANGTAG">LANGTAG</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
+      <td><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a> <code class="grammar-paren">(</code><code class="grammar-paren">(</code>"<code class="grammar-literal">^^</code>" <a href="#grammar-production-IRIREF">IRIREF</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <a href="#grammar-production-LANGDIR">LANGDIR</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-quotedTriple">
       <td>[7]</td>
@@ -60,11 +60,11 @@
       <td>::=</td>
       <td>"<code class="grammar-literal">_:</code>" <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">.</code>"<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
-    <tr id="grammar-production-LANGTAG">
+    <tr id="grammar-production-LANGDIR">
       <td>[11]</td>
-      <td><code>LANGTAG</code></td>
+      <td><code>LANGDIR</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">@</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">-</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">--</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
+      <td>"<code class="grammar-literal">@</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">-</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">--</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_QUOTE">
       <td>[12]</td>

--- a/spec/ntriples-bnf.html
+++ b/spec/ntriples-bnf.html
@@ -64,7 +64,7 @@
       <td>[11]</td>
       <td><code>LANGTAG</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">@</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">-</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-star">*</code></td>
+      <td>"<code class="grammar-literal">@</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">-</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">--</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_QUOTE">
       <td>[12]</td>

--- a/spec/ntriples-bnf.html
+++ b/spec/ntriples-bnf.html
@@ -35,7 +35,7 @@
       <td>[6]</td>
       <td><code>literal</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a> <code class="grammar-paren">(</code><code class="grammar-paren">(</code>"<code class="grammar-literal">^^</code>" <a href="#grammar-production-IRIREF">IRIREF</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <a href="#grammar-production-LANGDIR">LANGDIR</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
+      <td><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a> <code class="grammar-paren">(</code><code class="grammar-paren">(</code>"<code class="grammar-literal">^^</code>" <a href="#grammar-production-IRIREF">IRIREF</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <a href="#grammar-production-LANG_DIR">LANG_DIR</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-quotedTriple">
       <td>[7]</td>
@@ -60,9 +60,9 @@
       <td>::=</td>
       <td>"<code class="grammar-literal">_:</code>" <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">.</code>"<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
-    <tr id="grammar-production-LANGDIR">
+    <tr id="grammar-production-LANG_DIR">
       <td>[11]</td>
-      <td><code>LANGDIR</code></td>
+      <td><code>LANG_DIR</code></td>
       <td>::=</td>
       <td>"<code class="grammar-literal">@</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">-</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">--</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>

--- a/spec/ntriples.bnf
+++ b/spec/ntriples.bnf
@@ -3,14 +3,14 @@ triple            ::= subject predicate object '.'
 subject           ::= IRIREF | BLANK_NODE_LABEL | quotedTriple
 predicate         ::= IRIREF
 object            ::= IRIREF | BLANK_NODE_LABEL | literal | quotedTriple
-literal           ::= STRING_LITERAL_QUOTE ('^^' IRIREF | LANGTAG )?
+literal           ::= STRING_LITERAL_QUOTE ('^^' IRIREF | LANGDIR )?
 quotedTriple      ::= '<<' subject predicate object '>>'
 
 @terminals
 
 IRIREF            ::=  '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
 BLANK_NODE_LABEL  ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?
-LANGTAG           ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )* ( "--" [a-zA-Z]+ )?
+LANGDIR           ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )* ( "--" [a-zA-Z]+ )?
 STRING_LITERAL_QUOTE ::= '"' ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* '"'
 UCHAR             ::= ( "\u" HEX HEX HEX HEX )
                     | ( "\U" HEX HEX HEX HEX HEX HEX HEX HEX )

--- a/spec/ntriples.bnf
+++ b/spec/ntriples.bnf
@@ -3,14 +3,14 @@ triple            ::= subject predicate object '.'
 subject           ::= IRIREF | BLANK_NODE_LABEL | quotedTriple
 predicate         ::= IRIREF
 object            ::= IRIREF | BLANK_NODE_LABEL | literal | quotedTriple
-literal           ::= STRING_LITERAL_QUOTE ('^^' IRIREF | LANGDIR )?
+literal           ::= STRING_LITERAL_QUOTE ('^^' IRIREF | LANG_DIR )?
 quotedTriple      ::= '<<' subject predicate object '>>'
 
 @terminals
 
 IRIREF            ::=  '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
 BLANK_NODE_LABEL  ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?
-LANGDIR           ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )* ( "--" [a-zA-Z]+ )?
+LANG_DIR          ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )* ( "--" [a-zA-Z]+ )?
 STRING_LITERAL_QUOTE ::= '"' ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* '"'
 UCHAR             ::= ( "\u" HEX HEX HEX HEX )
                     | ( "\U" HEX HEX HEX HEX HEX HEX HEX HEX )

--- a/spec/ntriples.bnf
+++ b/spec/ntriples.bnf
@@ -10,7 +10,7 @@ quotedTriple      ::= '<<' subject predicate object '>>'
 
 IRIREF            ::=  '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
 BLANK_NODE_LABEL  ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?
-LANGTAG           ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )* ( "--" [a-zA-Z0-9]+ )?
+LANGTAG           ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )* ( "--" [a-zA-Z]+ )?
 STRING_LITERAL_QUOTE ::= '"' ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* '"'
 UCHAR             ::= ( "\u" HEX HEX HEX HEX )
                     | ( "\U" HEX HEX HEX HEX HEX HEX HEX HEX )

--- a/spec/ntriples.bnf
+++ b/spec/ntriples.bnf
@@ -10,11 +10,11 @@ quotedTriple      ::= '<<' subject predicate object '>>'
 
 IRIREF            ::=  '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
 BLANK_NODE_LABEL  ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?
-LANG_DIR          ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )* ( "--" [a-zA-Z]+ )?
+LANG_DIR          ::= '@' [a-zA-Z]+ ( '-' [a-zA-Z0-9]+ )* ( '--' [a-zA-Z]+ )?
 STRING_LITERAL_QUOTE ::= '"' ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* '"'
-UCHAR             ::= ( "\u" HEX HEX HEX HEX )
-                    | ( "\U" HEX HEX HEX HEX HEX HEX HEX HEX )
-ECHAR             ::= ("\" [tbnrf"'])
+UCHAR             ::= ( '\u' HEX HEX HEX HEX )
+                    | ( '\U' HEX HEX HEX HEX HEX HEX HEX HEX )
+ECHAR             ::= ('\' [tbnrf"'])
 PN_CHARS_BASE     ::= ([A-Z]
                     | [a-z]
                     | [#x00C0-#x00D6]
@@ -31,7 +31,7 @@ PN_CHARS_BASE     ::= ([A-Z]
                     | [#x10000-#xEFFFF])
 PN_CHARS_U        ::=  PN_CHARS_BASE | '_'
 PN_CHARS          ::= (PN_CHARS_U
-                    | "-"
+                    | '-'
                     | [0-9]
                     | #x00B7
                     | [#x0300-#x036F]

--- a/spec/ntriples.bnf
+++ b/spec/ntriples.bnf
@@ -10,7 +10,7 @@ quotedTriple      ::= '<<' subject predicate object '>>'
 
 IRIREF            ::=  '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
 BLANK_NODE_LABEL  ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?
-LANGTAG           ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )*
+LANGTAG           ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )* ( "--" [a-zA-Z0-9]+ )?
 STRING_LITERAL_QUOTE ::= '"' ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* '"'
 UCHAR             ::= ( "\u" HEX HEX HEX HEX )
                     | ( "\U" HEX HEX HEX HEX HEX HEX HEX HEX )


### PR DESCRIPTION
… and term construtors for creating directional language-tagged strings.

Fixes #32. Depends on w3c/rdf-concepts#48.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/pull/34.html" title="Last updated on Sep 25, 2023, 9:09 PM UTC (93ac7bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/34/43e8215...93ac7bc.html" title="Last updated on Sep 25, 2023, 9:09 PM UTC (93ac7bc)">Diff</a>