### PR TITLE
Updates location of the 1.2 version of the test suite.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -12,7 +12,7 @@
       localBiblio:          localBibliography,
       specStatus:           "ED",
       edDraftURI:           "https://w3c.github.io/rdf-n-triples/spec/",
-      testSuiteURI:         "https://w3c.github.io/rdf-tests/ntriples/", 
+      testSuiteURI:         "https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/", 
       shortName:            "rdf12-n-triples",
       subtitle   :          "A line-based syntax for an RDF graph",
       copyrightStart:       "2008",


### PR DESCRIPTION
New location is https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-n-triples/, which also references 1.1 tests.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/pull/47.html" title="Last updated on Nov 3, 2023, 8:06 PM UTC (e372eac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/47/1a6ecad...e372eac.html" title="Last updated on Nov 3, 2023, 8:06 PM UTC (e372eac)">Diff</a>