### PR TITLE
Adds a link to the text version of the BNF file.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -487,6 +487,7 @@
         production is allowed new lines in literals MUST be escaped.</p>
 
       <div data-include="ntriples-bnf.html"></div>
+      <p>A text version of this grammar is available <a href="ntriples.bnf">here</a>.</p>
     </section>
     
 


### PR DESCRIPTION
This makes it more convenient for people to access the EBNF without having to scrape the HTML.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/pull/54.html" title="Last updated on Sep 18, 2024, 7:39 PM UTC (230cb22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/54/d61882a...230cb22.html" title="Last updated on Sep 18, 2024, 7:39 PM UTC (230cb22)">Diff</a>