### PR TITLE
Add missing backslash to the ECHAR grammar production.

### DIFF
--- a/spec/ntriples-bnf.html
+++ b/spec/ntriples-bnf.html
@@ -82,7 +82,7 @@
       <td>[14]</td>
       <td><code>ECHAR</code></td>
       <td>::=</td>
-      <td>'<code class="grammar-literal">\</code>' <code class="grammar-brac">[</code><code class="grammar-literal">tbnrf&quot;&apos;</code><code class="grammar-brac">]</code></td>
+      <td>'<code class="grammar-literal">\</code>' <code class="grammar-brac">[</code><code class="grammar-literal">tbnrf\&quot;&apos;</code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_CHARS_BASE">
       <td>[15]</td>

--- a/spec/ntriples.bnf
+++ b/spec/ntriples.bnf
@@ -14,7 +14,7 @@ LANG_DIR          ::= '@' [a-zA-Z]+ ( '-' [a-zA-Z0-9]+ )* ( '--' [a-zA-Z]+ )?
 STRING_LITERAL_QUOTE ::= '"' ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* '"'
 UCHAR             ::= ( '\u' HEX HEX HEX HEX )
                     | ( '\U' HEX HEX HEX HEX HEX HEX HEX HEX )
-ECHAR             ::= ('\' [tbnrf"'])
+ECHAR             ::= ('\' [tbnrf\"'])
 PN_CHARS_BASE     ::= ([A-Z]
                     | [a-z]
                     | [#x00C0-#x00D6]


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/pull/65.html" title="Last updated on Jun 26, 2025, 5:15 PM UTC (cecf200)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/65/810dd57...cecf200.html" title="Last updated on Jun 26, 2025, 5:15 PM UTC (cecf200)">Diff</a>