### PR TITLE
Fix `dfn-literal`. add "period" before full-stop character, other misc.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -95,17 +95,23 @@
       .separated tbody tr td:nth-child(2) {padding: 3px 2px;}
       .separated tbody tr td:nth-child(3) {padding: 3px 2px;}
       .separated tbody tr td { border:1px solid black; text-align: center; min-width: 10vw }
-  }
+      table { word-break: normal; overflow-wrap: anywhere; }
+      table.ex, .ex th, .ex td { border: none; padding: 0; }
+      table.ex { font-size: 1.4vw; }
+      .separated tbody tr td:first-child, .separated tbody tr th:first-child {max-width: 220px; overflow-wrap: anywhere;}
 
-  table.simple { border-collapse:collapse;}
-  table.simple th, table.simple td  { border:1px solid black; padding:0.2em; }
+    }
+    .ex th { text-align: center; }
 
-  table.cp-definitions { border-collapse:collapse; background-color: #DDDDFF}
+    table.simple { border-collapse:collapse;}
+    table.simple th, table.simple td  { border:1px solid black; padding:0.2em; }
 
-  table.cp-definitions,
-  table.cp-definitions th,
-  table.cp-definitions td { border:0px solid black; padding:0.2em; }
-  table.cp-definitions td:nth-child(2) { text-align: center; }
+    table.cp-definitions { border-collapse:collapse; background-color: #DDDDFF}
+
+    table.cp-definitions,
+    table.cp-definitions th,
+    table.cp-definitions td { border:0px solid black; padding:0.2em; }
+    table.cp-definitions td:nth-child(2) { text-align: center; }
   </style>
 </head>
 <body>
@@ -850,10 +856,11 @@
               and <a href="#cp-greater-than"><code title="greater-than sign">&gt;</code></a> are taken,
               with escape sequences unescaped,
               to form the IRI.
-              The resulting IRI MUST comply with the
-              <a data-cite="RFC3987#section-2.2">syntactic restrictions</a> of generic IRI syntax,
-              and SHOULD conform to <a data-cite="RFC3986#section-3.3">section 3.3</a> of [[RFC3986]]
-              and comply with any narrower restrictions imposed by the corresponding IRI scheme specification.
+              <span id="tc-iriref-tests" data-tests="
+                syntax/index.html#ntriples12-bad-iri-1">The resulting IRI MUST comply with the
+                <a data-cite="RFC3987#section-2.2">syntactic restrictions</a> of generic IRI syntax,
+                and SHOULD conform to <a data-cite="RFC3986#section-3.3">section 3.3</a> of [[RFC3986]]
+                and comply with any narrower restrictions imposed by the corresponding IRI scheme specification.</span>
             </td>
           </tr>
           <tr id="handle-LANG_DIR">
@@ -868,13 +875,19 @@
               form the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
               and optionally the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">initial text direction</a>,
               if the matched characters include
-              <a href="#cp-hyphen-hyphen"><code>--</code></a>.<br/>
-              The <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
-              MUST be well-formed according to
-              <a data-cite="bcp47#section-2.2.9">section 2.2.9</a>
-              of [[!BCP47]].<br/>
-              If present, the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">initial text direction</a>
-              MUST be either `ltr` or `rtl`.<br/>
+              <a href="#cp-hyphen-hyphen" style="white-space: nowrap"><code>--</code></a>.
+              <span id="tc-langdir-tests" data-tests="
+                syntax/index.html#ntriples-langdir-bad-1,
+                syntax/index.html#ntriples-langdir-bad-2,
+                syntax/index.html#ntriples-langdir-bad-3,
+                syntax/index.html#ntriples-langdir-bad-4,
+                syntax/index.html#ntriples-langdir-bad-5">
+                The <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
+                MUST be well-formed according to
+                <a data-cite="bcp47#section-2.2.9">section 2.2.9</a>
+                of [[!BCP47]].
+                If present, the <a data-cite="RDF12-CONCEPTS#dfn-base-direction">initial text direction</a>
+                MUST be either `ltr` or `rtl`.</span>
             </td>
           </tr>
           <tr id="handle-STRING_LITERAL_QUOTE">


### PR DESCRIPTION
Fixes #71.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/pull/72.html" title="Last updated on Jul 30, 2025, 5:49 PM UTC (80683ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/72/aba3ff4...80683ce.html" title="Last updated on Jul 30, 2025, 5:49 PM UTC (80683ce)">Diff</a>