### PR TITLE
Add profile parameter

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1054,7 +1054,7 @@
     <dd>None</dd>
     <dt>Optional parameters:</dt>
     <dd><dl>
-      <dt><code>version</code></dt><dd>This parameter is optional but SHOULD be present when using RDF 1.2-specific features.
+      <dt><code>version</code></dt><dd>This parameter is optional but SHOULD be included when using RDF 1.2-specific features.
       If present, acceptable values of <code>version</code> are
       defined in <a data-cite="RDF12-CONCEPTS#defined-version-labels">2.1 Version Lables</a> in [[RDF12-CONCEPTS]].</dd>
       <dt><code>profile</code></dt>


### PR DESCRIPTION
I suggest we add an optional parameter "profile" to the N-Triples document (and, eventually, to the other concrete syntaxes).

It may be useful for specifying / requiring (with content negociation)  the canonical form of N-Triples.

I have my own ideas for other profiles for N-Triples / N-Quads, using tabs to separate the elements of asserted triples, making those files spreadsheet-friendly (as well as Unix-like-CLI-tools-friendly. I'm not suggesting to add this in the spec, but at least the profile parameter creates a hook for this.

The text added in the IANA section is mostly copied from the [JSON-LD spec](https://www.w3.org/TR/json-ld11/#iana-considerations).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/pull/76.html" title="Last updated on Dec 18, 2025, 5:41 PM UTC (9bd8f2b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/76/c89dac3...9bd8f2b.html" title="Last updated on Dec 18, 2025, 5:41 PM UTC (9bd8f2b)">Diff</a>