### PR TITLE
Dealing with pubrules and Gregg's editor status

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -32,15 +32,23 @@
       prevRecShortname:     "n-triples",
 
       editors: [
-        { name: "Gregg Kellogg", w3cid: "44770" },
+        {
+          name: "Gregg Kellogg",
+          w3cid: "44770",
+          //retiredDate: "2025-09-06", // Respec would automatically move Gregg to the 'Former Editors' section
+          note: "until 2025-09-06",
+          extras: [
+            {name: "in memoriam", class: "former"},
+          ],
+        },
         { name: "Dominik Tomaszuk", w3cid: "44239"},
       ],
 
       formerEditors:  [
-        { name: "Gavin Carothers" },
-        { name: "Andy Seaborne", w3cid: "29909"}
+        { name: "Gavin Carothers", note: "RDF 1.1" },
+        { name: "Andy Seaborne", note: "RDF 1.1" }
       ],
-
+      
       authors:  [
         { name: "David Beckett", url: "http://www.dajobe.org/", }
       ],


### PR DESCRIPTION
See https://github.com/w3c/rdf-concepts/pull/247

>the W3C automated process requires all editors to be active W3C members;
we discussed with the chairs and other co-editors and this solution was proposed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/pull/82.html" title="Last updated on Nov 6, 2025, 7:03 PM UTC (6819355)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/82/af466b4...6819355.html" title="Last updated on Nov 6, 2025, 7:03 PM UTC (6819355)">Diff</a>