### PR TITLE
Fix link text

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1061,7 +1061,7 @@
     <dt>Optional parameters:</dt>
     <dd><code>version</code> — this parameter is optional but SHOULD be present when using RDF 1.2-specific features.
       If present, acceptable values of <code>version</code> are
-      defined in <a data-cite="RDF12-CONCEPTS#defined-version-labels">2.1 Version Lables</a> in [[RDF12-CONCEPTS]].</dd>
+      defined in <a data-cite="RDF12-CONCEPTS#defined-version-labels">2.1 Version Labels</a> in [[RDF12-CONCEPTS]].</dd>
 
     <dt>Encoding considerations:</dt>
     <dd>The syntax of N-Triples is expressed over code points in Unicode [[UNICODE]]. The encoding is always UTF-8 [[UTF-8]].</dd>


### PR DESCRIPTION
"Lable" -> "Label"

(after #83)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/pull/86.html" title="Last updated on Dec 19, 2025, 8:54 AM UTC (9d656e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/86/3ceec92...9d656e8.html" title="Last updated on Dec 19, 2025, 8:54 AM UTC (9d656e8)">Diff</a>