### PR TITLE
Remove 'at risk' on VERSION from the change log

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1160,7 +1160,7 @@
       are not legal in N-Triples documents, nor as the value of a Unicode escape sequence.</li>
     <li>Added <a href="#sec-version"></a> and parser
       state and productions to announce the RDF version
-      associated with the input document. Note that this feature is at risk.
+      associated with the input document.
     </li>
   </ul>
 </section>


### PR DESCRIPTION
PR #85 removed the "at risk" box for issue 66.

This PR removes the text in the change log.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/pull/88.html" title="Last updated on Dec 29, 2025, 10:12 AM UTC (57463e0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/88/2424d1c...57463e0.html" title="Last updated on Dec 29, 2025, 10:12 AM UTC (57463e0)">Diff</a>