### PR TITLE
add paragraph stating that N-Triples 1.2 is not ambiguous for 1.1 implems

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -197,14 +197,15 @@
     </p>
 
     <p>
-      This specification extends the syntax defined in [[N-TRIPLES]] to support the new features introduced by [[RDF12-CONCEPTS]] compared to RDF 1.1.
+      This specification extends the syntax defined in [[N-TRIPLES]] to support the new features introduced by [[RDF12-CONCEPTS]].
       This extension is fully backward compatible:
-      any document complying with the old version is still complying with the new version, and parses to the exact same graph.
+      any document complying with the old version complies with the new version, and parses to the same graph.
       Furthermore, any document complying with the new version and containing only RDF 1.1 features is also compliant with the older version
-      (with the caveat of the `VERSION` directive, see <a href="#sec-version"></a>).
-      Finally, none of the new syntactic constructs were accepted by the old synyax.
-      This ensures that any N-Triples document containing RDF 1.2 new features does not comply with the old version of N-Triples,
-      and can therefore not be ambiguously parsed as a different graph by old implementations.
+      (with the exception of the `VERSION` directive; see <a href="#sec-version"></a>).
+      Finally, none of the new syntactic constructs are valid in the old syntax.
+      This means that any N-Triples document using RDF 1.2 features does not
+      comply with the previous version of this specification and cannot be
+      interpreted as a different graph under it.
     </p>
   </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -197,7 +197,7 @@
     </p>
 
     <p>
-      This specification extends the syntax defined in [[N-TRIPLES]] to support the new features introduced by [[RDF12-CONCEPTS]].
+      This specification extends the original N-Triples syntax, as defined in [[N-TRIPLES]], to support the new features introduced by [[RDF12-CONCEPTS]].
       This extension is fully backward compatible:
       any document complying with the old version complies with the new version, and parses to the same graph.
       Furthermore, any document complying with the new version and containing only RDF 1.1 features is also compliant with the older version

--- a/spec/index.html
+++ b/spec/index.html
@@ -195,6 +195,17 @@
       exactly each <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a> matching the N-Triples
       <a href="#grammar-production-triple"><code>triple</code></a> production.
     </p>
+
+    <p>
+      This specification extends the syntax defined in [[N-TRIPLES]] to support the new features introduced by [[RDF12-CONCEPTS]] compared to RDF 1.1.
+      This extension is fully backward compatible:
+      any document complying with the old version is still complying with the new version, and parses to the exact same graph.
+      Furthermore, any document complying with the new version and containing only RDF 1.1 features is also compliant with the older version
+      (with the caveat of the `VERSION` directive, see <a href="#sec-version"></a>).
+      Finally, none of the new syntactic constructs were accepted by the old synyax.
+      This ensures that any N-Triples document containing RDF 1.2 new features does not comply with the old version of N-Triples,
+      and can therefore not be ambiguously parsed as a different graph by old implementations.
+    </p>
   </section>
 
   <section id="sec-n-triples-language" class="informative">


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/pull/90.html" title="Last updated on Jan 15, 2026, 3:37 PM UTC (4bb8849)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/90/2424d1c...4bb8849.html" title="Last updated on Jan 15, 2026, 3:37 PM UTC (4bb8849)">Diff</a>