### PR TITLE
Scalar value range for \u escape sequences

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -588,7 +588,7 @@
     <h2>N-Triples Grammar</h2>
     <p>An <a>N-Triples document</a> is an <a data-cite="RDF12-CONCEPTS#dfn-rdf-string">RDF string</a> encoded in UTF-8 [[!RFC3629]].
     Only <a data-cite="I18N-GLOSSARY#dfn-scalar-value" class="lint-ignore">Unicode scalar values</a>,
-    in the ranges <code class="codepoint">U+0000</code> to <code class="codepoint">U+D7FF</code> 
+    in the ranges <code class="codepoint">U+0000</code> to <code class="codepoint">U+FFFF</code> 
     and <code class="codepoint">U+E000</code> to <code class="codepoint">U+10FFFF</code>,
     are allowed. This excludes 
     <a data-cite="I18N-GLOSSARY#dfn-surrogate" class="lint-ignore">surrogate code points</a>,


### PR DESCRIPTION
Turtle: https://github.com/w3c/rdf-turtle/pull/133
Issue: https://github.com/w3c/rdf-turtle/issues/131


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/pull/100.html" title="Last updated on Apr 7, 2026, 1:57 PM UTC (c709573)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/100/37c1a38...c709573.html" title="Last updated on Apr 7, 2026, 1:57 PM UTC (c709573)">Diff</a>