### PR TITLE
implement TAG recommendation about error handling

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -831,14 +831,15 @@
   <h2>Parsing</h2>
   <p>
   This section maps a string conforming to the grammar in <a href="#sec-grammar-grammar" class="sectionRef"></a>
-  to a set of triples by mapping strings matching productions and lexical tokens
+  to a stream of triples by mapping strings matching productions and lexical tokens
   to <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF terms</a> or their components (e.g., language tags, lexical forms of literals).
   Grammar productions change the parser state and emit triples.
   </p>
 
   <p id="must-signal-errors">
     A processor which detects errors on input MUST signal it as an error or a warning,
-    and MAY produce fewer triples than are described in the input (including no triples whatsoever).
+    and MAY emit only a subset of the triples that would otherwise have been emitted by
+    processing the error-free parts of the input, including no triples whatsoever).
   </p>
 
   <p class="note">
@@ -1003,9 +1004,11 @@
       </table>
 
       <p class="note">
-        In case the input contains errors,
-        consumers should consider information of any errors signaled by the processors,
-        when using the resulting graph,
+        When using the resulting graph,
+        consumers should consider the information in
+        any errors or warnings signaled by the processors,
+        as these may indicate that the input contains errors,
+        and the output may lack anticipated data and/or include
         as it may be incomplete and/or include
         <a data-cite="RDF12-CONCEPTS#dfn-ill-typed">ill-typed</a>
         or ill-formed terms.</p>
@@ -1013,7 +1016,7 @@
 
     <section id="rdf-triple-construction">
       <h3>RDF Triple Construction</h3>
-      <p>An <a>N-Triples document</a> defines an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graphs</a>
+      <p>An <a>N-Triples document</a> defines an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a>
         composed of a set of <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF Triples</a>.
         The <a href="#grammar-production-triple"><code>triple</code></a> production
         emits a triple defined by the terms constructed for
@@ -1271,7 +1274,8 @@
     </li>
     <li>Added a `profile` parameter to the media type in <a href="#sec-mediaReg-n-triples"></a>.
     </li>
-    <li>Added a <a href="#must-signal-errors">normative requirement</a> for processors to signal input errors (as error or warning).
+    <li>Added a <a href="#must-signal-errors">normative requirement</a> for processors to signal
+      input errors (as errors or warnings).
     </li>
 
   </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -847,7 +847,8 @@
   <p class="note">
     While earlier versions of this specification did not specify any behaviour on unrecognized input,
     all implementations known to the Working Group already behave consistently with the requirement above.
-    In particular, these implementations will signal an error when encountering any RDF 1.2 specific syntax unrecognised by those earlier versions,
+    In particular, these implementations will signal an error
+    when encountering any RDF 1.2 specific syntax unrecognised by those earlier versions,
     including the <code>VERSION</code> directive.
     They will not silently ignore or misinterpret such syntax.
   </p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -842,10 +842,11 @@
   </p>
 
   <p class="note">
-    While earlier versions of this specification did not specify any behaviour on erroneous input,
+    While earlier versions of this specification did not specify any behaviour on unrecognized input,
     all implementations known to the Working Group do comply with the requirement above.
-    In particular, these implementations will signal an error, as intended,
-    if they encounter the new `VERSION` directive.
+    In particular, these implementations will signal an error when they encounter any RDF 1.2 specific syntax,
+    including the VERSION directive.
+    They will not silently ignore or misinterpret it.
   </p>
 
   <section id="sec-parsing-state">

--- a/spec/index.html
+++ b/spec/index.html
@@ -1004,16 +1004,6 @@
           </tr>
         </tbody>
       </table>
-
-      <p class="note">
-        When using the resulting graph,
-        consumers should consider the information in
-        any errors or warnings signaled by the processor,
-        as these indicate that the input contains errors,
-        and the output may lack anticipated data and/or include
-        as it may be incomplete and/or include
-        <a data-cite="RDF12-CONCEPTS#dfn-ill-typed">ill-typed</a>
-        or ill-formed terms.</p>
     </section>
 
     <section id="rdf-triple-construction">

--- a/spec/index.html
+++ b/spec/index.html
@@ -830,16 +830,18 @@
 <section id="sec-parsing">
   <h2>Parsing</h2>
   <p>
-  This section maps a string conforming to the grammar in <a href="#sec-grammar-grammar" class="sectionRef"></a>
-  to a stream of triples by mapping strings matching productions and lexical tokens
-  to <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF terms</a> or their components (e.g., language tags, lexical forms of literals).
-  Grammar productions change the parser state and emit triples.
+    This section maps a string conforming to the grammar in <a href="#sec-grammar-grammar" class="sectionRef"></a>
+    to a stream of triples by mapping strings matching productions and lexical tokens
+    to <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF terms</a> or their components (e.g., language tags, lexical forms of literals).
+    Grammar productions change the parser state and emit triples.
   </p>
 
   <p id="must-signal-errors">
-    A processor which detects errors on input MUST signal it as an error or a warning,
-    and MAY emit only a subset of the triples that would otherwise have been emitted by
-    processing the error-free parts of the input, including no triples whatsoever).
+    A processor which detects errors on input MUST signal them as errors or warnings.
+    The exact output of the processor is not defined by this specification, including whether
+    any triples are emitted at all.
+    Any output SHOULD only contain a subset of the triples emitted from parsing
+    error-free regions of the input.
   </p>
 
   <p class="note">
@@ -1006,8 +1008,8 @@
       <p class="note">
         When using the resulting graph,
         consumers should consider the information in
-        any errors or warnings signaled by the processors,
-        as these may indicate that the input contains errors,
+        any errors or warnings signaled by the processor,
+        as these indicate that the input contains errors,
         and the output may lack anticipated data and/or include
         as it may be incomplete and/or include
         <a data-cite="RDF12-CONCEPTS#dfn-ill-typed">ill-typed</a>

--- a/spec/index.html
+++ b/spec/index.html
@@ -836,7 +836,7 @@
   Grammar productions change the parser state and emit triples.
   </p>
 
-  <p>
+  <p id="must-signal-errors">
     A processor which detects errors on input MUST signal it as an error or a warning,
     and MAY produce fewer triples than are described in the input (including no triples whatsoever).
   </p>
@@ -1269,6 +1269,8 @@
       associated with the input document.
     </li>
     <li>Added a `profile` parameter to the media type in <a href="#sec-mediaReg-n-triples"></a>.
+    </li>
+    <li>Added a <a href="#must-signal-errors">normative requirement</a> for processors to signal input errors (as error or warning).
     </li>
 
   </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -827,8 +827,29 @@
   </section>
   </section>
 
-  <section id="sec-parsing">
-    <h2>Parsing</h2>
+<section id="sec-parsing">
+  <h2>Parsing</h2>
+  <p>
+  This section maps a string conforming to the grammar in <a href="#sec-grammar-grammar" class="sectionRef"></a>
+  to a set of triples by mapping strings matching productions and lexical tokens
+  to <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF terms</a> or their components (e.g., language tags, lexical forms of literals).
+  Grammar productions change the parser state and emit triples.
+  </p>
+
+  <p>
+    A processor which detects errors on input MUST signal it as an error or a warning,
+    and MAY produce fewer triples than are described in the input (including no triples whatsoever).
+  </p>
+
+  <p class="note">
+    While earlier versions of this specification did not specify any behaviour on erroneous input,
+    all implementations known to the Working Group do comply with the requirement above.
+    In particular, these implementations will signal an error, as intended,
+    if they encounter the new `VERSION` directive.
+  </p>
+
+  <section id="sec-parsing-state">
+    <h3>Parser State</h3>
     <p>Parsing N-Triples requires a state of two items:</p>
     <ul>
       <li id="bnodeLabels">Map[string -&gt; <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>] <code class="dfn">bnodeLabels</code> — A mapping from string to blank node.</li>
@@ -842,10 +863,11 @@
         when it encounters a feature that does not match the value of |curVersion|.
       </li>
     </ul>
+  </section>
 
     <section id="sec-parsing-terms">
       <h3>RDF Term Constructors</h3>
-      <p>This table maps productions and lexical tokens to <code>RDF terms</code> or components of <code>RDF terms</code> listed in <a class="sectionRef sec-ref" href="#sec-parsing"></a>:</p>
+      <p>This table maps productions and lexical tokens to <a>RDF terms</a> or components of <a>RDF terms</a> listed in <a class="sectionRef sec-ref" href="#sec-parsing"></a>:</p>
       <table id="tab-term-constructors" class="separated">
         <thead>
           <tr><th>production</th><th>type</th><th>procedure</th></tr>
@@ -979,12 +1001,11 @@
         </tbody>
       </table>
 
-      <p class="note">As processors which detect errors on input can result in
-        graphs which contain fewer triples than are described in the input
-        (including no triples whatsoever),
-        consumers should consider information of any errors signaled
+      <p class="note">
+        In case the input contains errors,
+        consumers should consider information of any errors signaled by the processors,
         when using the resulting graph,
-        which may be incomplete and/or include
+        as it may be incomplete and/or include
         <a data-cite="RDF12-CONCEPTS#dfn-ill-typed">ill-typed</a>
         or ill-formed terms.</p>
     </section>
@@ -994,7 +1015,7 @@
       <p>An <a>N-Triples document</a> defines an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graphs</a>
         composed of a set of <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF Triples</a>.
         The <a href="#grammar-production-triple"><code>triple</code></a> production
-        produces a triple defined by the terms constructed for
+        emits a triple defined by the terms constructed for
         <a href="#grammar-production-subject"><code>subject</code></a>,
         <a href="#grammar-production-predicate"><code>predicate</code></a>, and
         <a href="#grammar-production-object"><code>object</code></a>.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -846,10 +846,10 @@
 
   <p class="note">
     While earlier versions of this specification did not specify any behaviour on unrecognized input,
-    all implementations known to the Working Group do comply with the requirement above.
-    In particular, these implementations will signal an error when they encounter any RDF 1.2 specific syntax,
-    including the VERSION directive.
-    They will not silently ignore or misinterpret it.
+    all implementations known to the Working Group already behave consistently with the requirement above.
+    In particular, these implementations will signal an error when encountering any RDF 1.2 specific syntax unrecognised by those earlier versions,
+    including the <code>VERSION</code> directive.
+    They will not silently ignore or misinterpret such syntax.
   </p>
 
   <section id="sec-parsing-state">


### PR DESCRIPTION
the goal of this PR is to include a normative statement about error handling, and a note about the existing implementations (as known to the WG), as was recommended by the TAG in last April.

To achieve this, I slightly restructured the Parsing section, making it more similiar to what we have in Turtle.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/pull/107.html" title="Last updated on Jun 23, 2026, 11:17 AM UTC (063dcaa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-triples/107/620b7b8...063dcaa.html" title="Last updated on Jun 23, 2026, 11:17 AM UTC (063dcaa)">Diff</a>